### PR TITLE
support freeze/unfreeze ballots

### DIFF
--- a/gov4git/cmd/ballot.go
+++ b/gov4git/cmd/ballot.go
@@ -43,6 +43,34 @@ var (
 		},
 	}
 
+	ballotFreezeCmd = &cobra.Command{
+		Use:   "freeze",
+		Short: "Freeze an open ballot",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			chg := ballot.Freeze(
+				ctx,
+				setup.Organizer,
+				ns.ParseFromPath(ballotName),
+			)
+			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
+		},
+	}
+
+	ballotUnfreezeCmd = &cobra.Command{
+		Use:   "unfreeze",
+		Short: "Unfreeze an open ballot",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			chg := ballot.Unfreeze(
+				ctx,
+				setup.Organizer,
+				ns.ParseFromPath(ballotName),
+			)
+			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
+		},
+	}
+
 	ballotCloseCmd = &cobra.Command{
 		Use:   "close",
 		Short: "Close an open ballot",
@@ -193,6 +221,16 @@ func init() {
 	ballotCloseCmd.MarkFlagRequired("name")
 	ballotCloseCmd.Flags().StringVar(&ballotSummary, "summary", "", "summary")
 	ballotCloseCmd.MarkFlagRequired("summary")
+
+	// freeze
+	ballotCmd.AddCommand(ballotFreezeCmd)
+	ballotFreezeCmd.Flags().StringVar(&ballotName, "name", "", "ballot name")
+	ballotFreezeCmd.MarkFlagRequired("name")
+
+	// unfreeze
+	ballotCmd.AddCommand(ballotUnfreezeCmd)
+	ballotUnfreezeCmd.Flags().StringVar(&ballotName, "name", "", "ballot name")
+	ballotUnfreezeCmd.MarkFlagRequired("name")
 
 	// show open
 	ballotCmd.AddCommand(ballotShowOpenCmd)

--- a/proto/ballot/ballot/freeze.go
+++ b/proto/ballot/ballot/freeze.go
@@ -1,0 +1,53 @@
+package ballot
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gov4git/gov4git/proto"
+	"github.com/gov4git/gov4git/proto/ballot/common"
+	"github.com/gov4git/gov4git/proto/ballot/load"
+	"github.com/gov4git/gov4git/proto/gov"
+	"github.com/gov4git/gov4git/proto/id"
+	"github.com/gov4git/lib4git/git"
+	"github.com/gov4git/lib4git/must"
+	"github.com/gov4git/lib4git/ns"
+)
+
+func Freeze(
+	ctx context.Context,
+	govAddr gov.OrganizerAddress,
+	ballotName ns.NS,
+) git.ChangeNoResult {
+
+	govCloned := id.CloneOwner(ctx, id.OwnerAddress(govAddr))
+	chg := FreezeStageOnly(ctx, govAddr, govCloned, ballotName)
+	proto.Commit(ctx, govCloned.Public.Tree(), chg.Msg)
+	govCloned.Public.Push(ctx)
+	return chg
+}
+
+func FreezeStageOnly(
+	ctx context.Context,
+	govAddr gov.OrganizerAddress,
+	govCloned id.OwnerCloned,
+	ballotName ns.NS,
+) git.ChangeNoResult {
+
+	govTree := govCloned.Public.Tree()
+
+	// verify ad and strategy are present
+	ad, _ := load.LoadStrategy(ctx, govTree, ballotName, false)
+
+	// verify ballot is not already frozen
+	if ad.Frozen {
+		must.Errorf(ctx, "ballot already frozen")
+	}
+	ad.Frozen = true
+
+	// write updated ad
+	openAdNS := common.OpenBallotNS(ballotName).Sub(common.AdFilebase)
+	git.ToFileStage(ctx, govTree, openAdNS.Path(), ad)
+
+	return git.ChangeNoResult{Msg: fmt.Sprintf("Freeze ballot %v", ballotName)}
+}

--- a/proto/ballot/ballot/open.go
+++ b/proto/ballot/ballot/open.go
@@ -69,6 +69,7 @@ func OpenStageOnly(
 		Choices:      choices,
 		Strategy:     strat.Name(),
 		Participants: participants,
+		Frozen:       false,
 		ParentCommit: git.Head(ctx, govCloned.Repo()),
 	}
 	git.ToFileStage(ctx, govCloned.Tree(), openAdNS.Path(), ad)

--- a/proto/ballot/ballot/tally.go
+++ b/proto/ballot/ballot/tally.go
@@ -43,6 +43,11 @@ func TallyStageOnly(
 
 	ad, strat := load.LoadStrategy(ctx, communityTree, ballotName, false)
 
+	// if the ballot is frozen, don't tally
+	if ad.Frozen {
+		return git.Change[common.Tally]{Msg: "Ballot is frozen"}, false
+	}
+
 	// list participating users
 	users := member.ListGroupUsersLocal(ctx, communityTree, ad.Participants)
 

--- a/proto/ballot/ballot/unfreeze.go
+++ b/proto/ballot/ballot/unfreeze.go
@@ -1,0 +1,53 @@
+package ballot
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gov4git/gov4git/proto"
+	"github.com/gov4git/gov4git/proto/ballot/common"
+	"github.com/gov4git/gov4git/proto/ballot/load"
+	"github.com/gov4git/gov4git/proto/gov"
+	"github.com/gov4git/gov4git/proto/id"
+	"github.com/gov4git/lib4git/git"
+	"github.com/gov4git/lib4git/must"
+	"github.com/gov4git/lib4git/ns"
+)
+
+func Unfreeze(
+	ctx context.Context,
+	govAddr gov.OrganizerAddress,
+	ballotName ns.NS,
+) git.ChangeNoResult {
+
+	govCloned := id.CloneOwner(ctx, id.OwnerAddress(govAddr))
+	chg := UnfreezeStageOnly(ctx, govAddr, govCloned, ballotName)
+	proto.Commit(ctx, govCloned.Public.Tree(), chg.Msg)
+	govCloned.Public.Push(ctx)
+	return chg
+}
+
+func UnfreezeStageOnly(
+	ctx context.Context,
+	govAddr gov.OrganizerAddress,
+	govCloned id.OwnerCloned,
+	ballotName ns.NS,
+) git.ChangeNoResult {
+
+	govTree := govCloned.Public.Tree()
+
+	// verify ad and strategy are present
+	ad, _ := load.LoadStrategy(ctx, govTree, ballotName, false)
+
+	// verify ballot is frozen
+	if !ad.Frozen {
+		must.Errorf(ctx, "ballot is not frozen")
+	}
+	ad.Frozen = false
+
+	// write updated ad
+	openAdNS := common.OpenBallotNS(ballotName).Sub(common.AdFilebase)
+	git.ToFileStage(ctx, govTree, openAdNS.Path(), ad)
+
+	return git.ChangeNoResult{Msg: fmt.Sprintf("Unfreeze ballot %v", ballotName)}
+}

--- a/proto/ballot/ballot/vote.go
+++ b/proto/ballot/ballot/vote.go
@@ -43,6 +43,11 @@ func VoteStageOnly(
 
 	ad, strat := load.LoadStrategy(ctx, govCloned.Tree(), ballotName, false)
 
+	// if the ballot is frozen, refuse to cast a vote
+	if ad.Frozen {
+		must.Errorf(ctx, "ballot is frozen")
+	}
+
 	verifyElections(ctx, strat, voterAddr, govAddr, voterOwner, govCloned, ad, elections)
 	envelope := common.VoteEnvelope{
 		AdCommit:  git.Head(ctx, govCloned.Repo()),

--- a/proto/ballot/common/schema.go
+++ b/proto/ballot/common/schema.go
@@ -38,6 +38,7 @@ type Advertisement struct {
 	Choices      []string       `json:"choices"`
 	Strategy     string         `json:"strategy"`
 	Participants member.Group   `json:"participants_group"`
+	Frozen       bool           `json:"frozen"` // if frozen, the ballot is not accepting votes
 	ParentCommit git.CommitHash `json:"parent_commit"`
 }
 

--- a/test/ballot/freeze_test.go
+++ b/test/ballot/freeze_test.go
@@ -1,0 +1,101 @@
+package ballot
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gov4git/gov4git/proto/ballot/ballot"
+	"github.com/gov4git/gov4git/proto/ballot/common"
+	"github.com/gov4git/gov4git/proto/ballot/qv"
+	"github.com/gov4git/gov4git/proto/member"
+	"github.com/gov4git/gov4git/test"
+	"github.com/gov4git/lib4git/must"
+	"github.com/gov4git/lib4git/ns"
+	"github.com/gov4git/lib4git/testutil"
+)
+
+func TestFreezeBallot(t *testing.T) {
+	ctx := testutil.NewCtx()
+	cty := test.NewTestCommunity(t, ctx, 2)
+
+	ballotName := ns.NS{"a", "b", "c"}
+	choices := []string{"x", "y", "z"}
+
+	// open
+	strat := qv.PriorityPoll{UseVotingCredits: false}
+	openChg := ballot.Open(
+		ctx,
+		strat,
+		cty.Gov(),
+		ballotName,
+		"ballot title",
+		"ballot description",
+		choices,
+		member.Everybody,
+	)
+	fmt.Println("open: ", openChg)
+
+	// vote
+	elections := common.Elections{
+		{
+			VoteChoice:         choices[0],
+			VoteStrengthChange: 1.0,
+		},
+	}
+	voteChg := ballot.Vote(
+		ctx,
+		cty.MemberOwner(0),
+		cty.Gov(),
+		ballotName,
+		elections,
+	)
+	fmt.Println("vote: ", voteChg)
+
+	// freeze ballot
+	freezeChg := ballot.Freeze(
+		ctx,
+		cty.Organizer(),
+		ballotName,
+	)
+	fmt.Println("freeze: ", freezeChg)
+
+	// try voting while frozen
+	if must.Try(
+		func() {
+			ballot.Vote(
+				ctx,
+				cty.MemberOwner(0),
+				cty.Gov(),
+				ballotName,
+				elections,
+			)
+		},
+	) == nil {
+		t.Fatalf("voting on a frozen ballot should have failed")
+	}
+
+	// unfreeze ballot
+	unfreezeChg := ballot.Unfreeze(
+		ctx,
+		cty.Organizer(),
+		ballotName,
+	)
+	fmt.Println("unfreeze: ", unfreezeChg)
+
+	// tally
+	tallyChg := ballot.Tally(
+		ctx,
+		cty.Organizer(),
+		ballotName,
+	)
+	fmt.Println("tally: ", tallyChg)
+	if len(tallyChg.Result.Votes) != 1 {
+		t.Errorf("expecting 1 vote, got %v", len(tallyChg.Result.Votes))
+	}
+
+	// close
+	closeChg := ballot.Close(ctx, cty.Organizer(), ballotName, common.Summary("ok"))
+	fmt.Println("close: ", closeChg)
+
+	// testutil.Hang()
+}


### PR DESCRIPTION
Ballots can be frozen/unfrozen while they are open, using `gov4git ballot un/freeze`.
Frozen ballots cannot be tallied.
Voting on frozen ballots fails.

