### PR TITLE
community-level sync operation

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,4 @@
-- [ ] test tally all
+- [x] test tally all
 - [ ] tallying frozen ops consumes pending user votes
 - [x] top-level sync operation
   - [ ] test sync

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,6 @@
+- [ ] test tally all
+- [ ] tallying frozen ops consumes pending user votes
+- [x] top-level sync operation
+  - [ ] test sync
+  - [ ] test sync cli api
+  - [x] plumb through to cli

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,6 +1,0 @@
-- [x] test tally all
-- [ ] tallying frozen ops consumes pending user votes
-- [x] top-level sync operation
-  - [x] test sync
-  - [ ] test sync cli api
-  - [x] plumb through to cli

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,6 +1,6 @@
 - [x] test tally all
 - [ ] tallying frozen ops consumes pending user votes
 - [x] top-level sync operation
-  - [ ] test sync
+  - [x] test sync
   - [ ] test sync cli api
   - [x] plumb through to cli

--- a/gov4git/cmd/root.go
+++ b/gov4git/cmd/root.go
@@ -46,6 +46,7 @@ func init() {
 	rootCmd.AddCommand(balanceCmd)
 	rootCmd.AddCommand(bureauCmd)
 	rootCmd.AddCommand(vendorCmd)
+	rootCmd.AddCommand(syncCmd)
 }
 
 func initAfterFlags() {

--- a/gov4git/cmd/sync.go
+++ b/gov4git/cmd/sync.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gov4git/gov4git/proto/sync"
+	"github.com/gov4git/lib4git/form"
+	"github.com/spf13/cobra"
+)
+
+var (
+	syncCmd = &cobra.Command{
+		Use:   "sync",
+		Short: "Sync governance with the community",
+		Long: `
+Sync is the heartbeat that advances the state of the governance forward.
+Sync fetches all outstanding votes from community users and incorporates them in ballot tallies.
+Sync also fetches and processes all outstanding service requests from community users.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			LoadConfig()
+			chg := sync.Sync(ctx, setup.Organizer)
+			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
+		},
+	}
+)

--- a/proto/ballot/ballot/all.go
+++ b/proto/ballot/ballot/all.go
@@ -1,0 +1,95 @@
+package ballot
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gov4git/gov4git/proto"
+	"github.com/gov4git/gov4git/proto/ballot/common"
+	"github.com/gov4git/gov4git/proto/gov"
+	"github.com/gov4git/gov4git/proto/id"
+	"github.com/gov4git/gov4git/proto/member"
+	"github.com/gov4git/lib4git/form"
+	"github.com/gov4git/lib4git/git"
+)
+
+func TallyAll(
+	ctx context.Context,
+	govAddr gov.OrganizerAddress,
+) git.Change[form.Map, []common.Tally] {
+
+	govOwner := id.CloneOwner(ctx, id.OwnerAddress(govAddr))
+	chg := TallyAllStageOnly(ctx, govAddr, govOwner)
+	if len(chg.Result) == 0 {
+		return chg
+	}
+	proto.Commit(ctx, govOwner.Public.Tree(), chg)
+	govOwner.Public.Push(ctx)
+	return chg
+}
+
+func TallyAllStageOnly(
+	ctx context.Context,
+	govAddr gov.OrganizerAddress,
+	govOwner id.OwnerCloned,
+) git.Change[form.Map, []common.Tally] {
+
+	// list all open ballots
+	communityTree := govOwner.Public.Tree()
+	ads := ListLocal(ctx, communityTree, false)
+
+	// compute union of all voter accounts from all open ballots
+	adVoters := make([]adVoters, len(ads))
+	allVoters := map[member.User]member.Account{}
+	for i, ad := range ads {
+		adVoters[i].ad = &ad
+		adVoters[i].voterAccounts = map[member.User]member.Account{}
+		adVoters[i].voterClones = map[member.User]git.Cloned{}
+		adVoters[i].voters = member.ListGroupUsersLocal(ctx, communityTree, ad.Participants)
+		for _, user := range adVoters[i].voters {
+			if _, ok := allVoters[user]; !ok {
+				account := member.GetUserLocal(ctx, communityTree, user)
+				adVoters[i].voterAccounts[user] = account
+				allVoters[user] = account
+			}
+		}
+	}
+
+	// fetch repos of all participating users
+	allVoterClones := map[member.User]git.Cloned{}
+	for u, a := range allVoters {
+		allVoterClones[u] = git.CloneOne(ctx, git.Address(a.PublicAddress))
+	}
+
+	// populate ad voter structures
+	for i, ad := range adVoters {
+		for u := range ad.voterAccounts {
+			adVoters[i].voterClones[u] = allVoterClones[u]
+		}
+	}
+
+	// perform tallies for all open ballots
+	tallyChanges := []git.Change[map[string]form.Form, common.Tally]{}
+	tallies := []common.Tally{}
+	for _, adv := range adVoters {
+		if tallyChg, changed := tallyVotersClonedStageOnly(ctx, govAddr, govOwner, adv.ad.Name, adv.voterAccounts, adv.voterClones); changed {
+			tallyChanges = append(tallyChanges, tallyChg)
+			tallies = append(tallies, tallyChg.Result)
+		}
+	}
+
+	return git.NewChange(
+		fmt.Sprintf("Tallied votes on all ballots"),
+		"ballot_tally_all",
+		form.Map{},
+		tallies,
+		form.ToForms(tallyChanges),
+	)
+}
+
+type adVoters struct {
+	ad            *common.Advertisement
+	voters        []member.User
+	voterAccounts map[member.User]member.Account
+	voterClones   map[member.User]git.Cloned
+}

--- a/proto/ballot/ballot/fetch.go
+++ b/proto/ballot/ballot/fetch.go
@@ -42,6 +42,19 @@ func fetchVotes(
 	user member.User,
 	account member.Account,
 ) git.Change[form.Map, FetchedVotes] {
+	userCloned := git.CloneOne(ctx, git.Address(account.PublicAddress))
+	return fetchVotesCloned(ctx, govAddr, govOwner, ballotName, user, account, userCloned)
+}
+
+func fetchVotesCloned(
+	ctx context.Context,
+	govAddr gov.OrganizerAddress,
+	govOwner id.OwnerCloned,
+	ballotName ns.NS,
+	user member.User,
+	account member.Account,
+	userCloned git.Cloned,
+) git.Change[form.Map, FetchedVotes] {
 
 	fetched := FetchedVotes{}
 	respond := func(ctx context.Context, req common.VoteEnvelope, _ id.SignedPlaintext) (resp common.VoteEnvelope, err error) {
@@ -58,7 +71,7 @@ func fetchVotes(
 		return req, nil
 	}
 
-	voterPublicTree := git.CloneOne(ctx, git.Address(account.PublicAddress)).Tree()
+	voterPublicTree := userCloned.Tree()
 	mail.ReceiveSignedStageOnly(
 		ctx,
 		govOwner,

--- a/proto/sync/sync.go
+++ b/proto/sync/sync.go
@@ -1,0 +1,35 @@
+package sync
+
+import (
+	"context"
+
+	"github.com/gov4git/gov4git/proto/ballot/ballot"
+	"github.com/gov4git/gov4git/proto/bureau"
+	"github.com/gov4git/gov4git/proto/gov"
+	"github.com/gov4git/gov4git/proto/member"
+	"github.com/gov4git/lib4git/form"
+	"github.com/gov4git/lib4git/git"
+)
+
+func Sync(
+	ctx context.Context,
+	govAddr gov.OrganizerAddress,
+) git.Change[form.Map, form.Map] {
+
+	// collect votes and tally all open ballots
+	tallyChg := ballot.TallyAll(ctx, govAddr)
+
+	// process bureau requests by users
+	bureauChg := bureau.Process(ctx, govAddr, member.Everybody)
+
+	return git.NewChange(
+		"Governance-community sync",
+		"sync_sync",
+		form.Map{},
+		form.Map{
+			"tally_result":  tallyChg.Result,
+			"bureau_result": bureauChg.Result,
+		},
+		form.Forms{tallyChg, bureauChg},
+	)
+}

--- a/test/api/testdata/script/ballot.txt
+++ b/test/api/testdata/script/ballot.txt
@@ -27,9 +27,15 @@ gov4git ballot tally --name ballot_1/xyz
 gov4git ballot show-open --name ballot_1/xyz
 stdout '"score": 3'
 
+gov4git ballot vote --name ballot_1/xyz --choices choice-1 --strengths 7.0
+gov4git sync
+
+gov4git ballot show-open --name ballot_1/xyz
+stdout '"score": 4'
+
 gov4git ballot close --name ballot_1/xyz
 gov4git ballot list-closed
 stdout ballot_1
 
 gov4git ballot show-closed --name ballot_1/xyz
-stdout '"score": 3'
+stdout '"score": 4'

--- a/test/ballot/freeze_test.go
+++ b/test/ballot/freeze_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gov4git/lib4git/testutil"
 )
 
-func TestFreezeBallot(t *testing.T) {
+func TestVoteFreezeVote(t *testing.T) {
 	ctx := testutil.NewCtx()
 	cty := test.NewTestCommunity(t, ctx, 2)
 
@@ -72,6 +72,43 @@ func TestFreezeBallot(t *testing.T) {
 	// close
 	closeChg := ballot.Close(ctx, cty.Organizer(), ballotName, false)
 	fmt.Println("close: ", form.SprintJSON(closeChg))
+
+	// testutil.Hang()
+}
+
+// TestVoteFreezeTally tests that votes made during a freeze are consumed and discarded by tallying.
+func TestVoteFreezeTally(t *testing.T) {
+	ctx := testutil.NewCtx()
+	cty := test.NewTestCommunity(t, ctx, 2)
+
+	ballotName := ns.NS{"a", "b", "c"}
+	choices := []string{"x", "y", "z"}
+
+	// open
+	strat := qv.QV{}
+	openChg := ballot.Open(ctx, strat, cty.Gov(), ballotName, "ballot title", "ballot description", choices, member.Everybody)
+	fmt.Println("open: ", form.SprintJSON(openChg))
+
+	// give voter credits
+	balance.Set(ctx, cty.Gov(), cty.MemberUser(0), qv.VotingCredits, 1.0)
+
+	// vote
+	elections := common.Elections{
+		common.NewElection(choices[0], 1.0),
+	}
+	voteChg := ballot.Vote(ctx, cty.MemberOwner(0), cty.Gov(), ballotName, elections)
+	fmt.Println("vote: ", form.SprintJSON(voteChg))
+
+	// freeze
+	freezeChg := ballot.Freeze(ctx, cty.Organizer(), ballotName)
+	fmt.Println("freeze: ", form.SprintJSON(freezeChg))
+
+	// tally
+	tallyChg := ballot.Tally(ctx, cty.Organizer(), ballotName)
+	fmt.Println("tally: ", form.SprintJSON(tallyChg))
+	if tallyChg.Result.Scores[choices[0]] != 0.0 {
+		t.Errorf("expecting %v, got %v", 0.0, tallyChg.Result.Scores[choices[0]])
+	}
 
 	// testutil.Hang()
 }

--- a/test/sync/sync_test.go
+++ b/test/sync/sync_test.go
@@ -1,0 +1,62 @@
+package sync
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/gov4git/gov4git/proto/balance"
+	"github.com/gov4git/gov4git/proto/ballot/ballot"
+	"github.com/gov4git/gov4git/proto/ballot/common"
+	"github.com/gov4git/gov4git/proto/ballot/qv"
+	"github.com/gov4git/gov4git/proto/member"
+	"github.com/gov4git/gov4git/proto/sync"
+	"github.com/gov4git/gov4git/test"
+	"github.com/gov4git/lib4git/form"
+	"github.com/gov4git/lib4git/ns"
+	"github.com/gov4git/lib4git/testutil"
+)
+
+func TestSync(t *testing.T) {
+	ctx := testutil.NewCtx()
+	cty := test.NewTestCommunity(t, ctx, 2)
+
+	ballotName0 := ns.NS{"a", "b", "c"}
+	ballotName1 := ns.NS{"d", "e", "f"}
+	choices := []string{"x", "y", "z"}
+
+	// open two ballots
+	strat := qv.QV{}
+	openChg0 := ballot.Open(ctx, strat, cty.Gov(), ballotName0, "ballot_0", "ballot 0", choices, member.Everybody)
+	fmt.Println("open 0: ", form.SprintJSON(openChg0))
+	openChg1 := ballot.Open(ctx, strat, cty.Gov(), ballotName1, "ballot_1", "ballot 1", choices, member.Everybody)
+	fmt.Println("open 1: ", form.SprintJSON(openChg1))
+
+	// give credits to users
+	balance.Set(ctx, cty.Gov(), cty.MemberUser(0), qv.VotingCredits, 5.0)
+	balance.Set(ctx, cty.Gov(), cty.MemberUser(1), qv.VotingCredits, 5.0)
+
+	// vote
+	elections0 := common.Elections{common.NewElection(choices[0], 5.0)}
+	elections1 := common.Elections{common.NewElection(choices[0], -5.0)}
+	voteChg0 := ballot.Vote(ctx, cty.MemberOwner(0), cty.Gov(), ballotName0, elections0)
+	fmt.Println("vote 0: ", form.SprintJSON(voteChg0))
+	voteChg1 := ballot.Vote(ctx, cty.MemberOwner(1), cty.Gov(), ballotName1, elections1)
+	fmt.Println("vote 1: ", form.SprintJSON(voteChg1))
+
+	// tally
+	syncChg := sync.Sync(ctx, cty.Organizer())
+	fmt.Println("sync: ", form.SprintJSON(syncChg))
+
+	// verify tallies are correct
+	ast0 := ballot.Show(ctx, cty.Gov(), ballotName0, false)
+	if ast0.Tally.Scores[choices[0]] != math.Sqrt(5.0) {
+		t.Errorf("expecting %v, got %v", math.Sqrt(5.0), ast0.Tally.Scores[choices[0]])
+	}
+	ast1 := ballot.Show(ctx, cty.Gov(), ballotName1, false)
+	if ast1.Tally.Scores[choices[0]] != -math.Sqrt(5.0) {
+		t.Errorf("expecting %v, got %v", -math.Sqrt(5.0), ast1.Tally.Scores[choices[0]])
+	}
+
+	// testutil.Hang()
+}


### PR DESCRIPTION
- [x] add a top-level `Sync` operation, to be executed by a cronjob, performing all community housekeeping tasks (like tallying, servicing bureau requests, and so on)
- [x] add `TallyAll` which tallies all open ballots in a communication-efficient manner, cloning each voter's repo once
- [x] tallying frozen ballots processes any user votes and files them as discarded

Resolves https://github.com/gov4git/gov4git/issues/52