### PR TITLE
handle ballot state uniformly

### DIFF
--- a/gov4git/cmd/ballot.go
+++ b/gov4git/cmd/ballot.go
@@ -90,9 +90,9 @@ var (
 		},
 	}
 
-	ballotShowOpenCmd = &cobra.Command{
-		Use:   "show-open",
-		Short: "Show open ballot",
+	ballotShowCmd = &cobra.Command{
+		Use:   "show",
+		Short: "Show ballot details",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
 			LoadConfig()
@@ -100,31 +100,14 @@ var (
 				ctx,
 				setup.Gov,
 				ns.ParseFromPath(ballotName),
-				false,
 			)
 			fmt.Fprint(os.Stdout, form.SprintJSON(r))
 		},
 	}
 
-	ballotShowClosedCmd = &cobra.Command{
-		Use:   "show-closed",
-		Short: "Show closed ballot",
-		Long:  ``,
-		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			r := ballot.Show(
-				ctx,
-				setup.Gov,
-				ns.ParseFromPath(ballotName),
-				true,
-			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(r))
-		},
-	}
-
-	ballotListOpenCmd = &cobra.Command{
-		Use:   "list-open",
-		Short: "List open ballots",
+	ballotListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List ballots",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
 			LoadConfig()
@@ -132,27 +115,6 @@ var (
 				ctx,
 				setup.Gov,
 				false,
-			)
-			if ballotOnlyNames {
-				for _, n := range common.AdsToBallotNames(ls) {
-					fmt.Println(n)
-				}
-			} else {
-				fmt.Fprint(os.Stdout, form.SprintJSON(ls))
-			}
-		},
-	}
-
-	ballotListClosedCmd = &cobra.Command{
-		Use:   "list-closed",
-		Short: "List closed ballots",
-		Long:  ``,
-		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			ls := ballot.List(
-				ctx,
-				setup.Gov,
-				true,
 			)
 			if ballotOnlyNames {
 				for _, n := range common.AdsToBallotNames(ls) {
@@ -241,23 +203,14 @@ func init() {
 	ballotUnfreezeCmd.Flags().StringVar(&ballotName, "name", "", "ballot name")
 	ballotUnfreezeCmd.MarkFlagRequired("name")
 
-	// show open
-	ballotCmd.AddCommand(ballotShowOpenCmd)
-	ballotShowOpenCmd.Flags().StringVar(&ballotName, "name", "", "ballot name")
-	ballotShowOpenCmd.MarkFlagRequired("name")
+	// show
+	ballotCmd.AddCommand(ballotShowCmd)
+	ballotShowCmd.Flags().StringVar(&ballotName, "name", "", "ballot name")
+	ballotShowCmd.MarkFlagRequired("name")
 
-	// show closed
-	ballotCmd.AddCommand(ballotShowClosedCmd)
-	ballotShowClosedCmd.Flags().StringVar(&ballotName, "name", "", "ballot name")
-	ballotShowClosedCmd.MarkFlagRequired("name")
-
-	// list open
-	ballotCmd.AddCommand(ballotListOpenCmd)
-	ballotListOpenCmd.Flags().BoolVar(&ballotOnlyNames, "only_names", false, "list only ballot names")
-
-	// list closed
-	ballotCmd.AddCommand(ballotListClosedCmd)
-	ballotListClosedCmd.Flags().BoolVar(&ballotOnlyNames, "only_names", false, "list only ballot names")
+	// list
+	ballotCmd.AddCommand(ballotListCmd)
+	ballotListCmd.Flags().BoolVar(&ballotOnlyNames, "only_names", false, "list only ballot names")
 
 	// tally
 	ballotCmd.AddCommand(ballotTallyCmd)

--- a/proto/ballot/ballot/all.go
+++ b/proto/ballot/ballot/all.go
@@ -36,7 +36,7 @@ func TallyAllStageOnly(
 
 	// list all open ballots
 	communityTree := govOwner.Public.Tree()
-	ads := ListLocal(ctx, communityTree, false)
+	ads := common.FilterOpenClosedAds(false, ListLocal(ctx, communityTree))
 
 	// compute union of all voter accounts from all open ballots
 	adVoters := make([]adVoters, len(ads))

--- a/proto/ballot/ballot/close.go
+++ b/proto/ballot/ballot/close.go
@@ -38,8 +38,8 @@ func CloseStageOnly(
 	govTree := govCloned.Public.Tree()
 
 	// verify ad and strategy are present
-	ad, strat := load.LoadStrategy(ctx, govTree, ballotName, false)
-	tally := LoadTally(ctx, govTree, ballotName, false)
+	ad, strat := load.LoadStrategy(ctx, govTree, ballotName)
+	tally := LoadTally(ctx, govTree, ballotName)
 	var chg git.Change[map[string]form.Form, common.Outcome]
 	if cancel {
 		chg = strat.Cancel(ctx, govCloned, &ad, &tally)
@@ -48,12 +48,13 @@ func CloseStageOnly(
 	}
 
 	// write outcome
-	openOutcomeNS := common.OpenBallotNS(ballotName).Sub(common.OutcomeFilebase)
+	openOutcomeNS := common.BallotPath(ballotName).Sub(common.OutcomeFilebase)
 	git.ToFileStage(ctx, govTree, openOutcomeNS.Path(), chg.Result)
 
-	openNS := common.OpenBallotNS(ballotName)
-	closedNS := common.ClosedBallotNS(ballotName)
-	git.RenameStage(ctx, govTree, openNS.Path(), closedNS.Path())
+	// write state
+	ad.Closed = true
+	openAdNS := common.BallotPath(ballotName).Sub(common.AdFilebase)
+	git.ToFileStage(ctx, govTree, openAdNS.Path(), ad)
 
 	return chg
 }

--- a/proto/ballot/ballot/freeze.go
+++ b/proto/ballot/ballot/freeze.go
@@ -36,17 +36,15 @@ func FreezeStageOnly(
 
 	govTree := govCloned.Public.Tree()
 
-	// verify ad and strategy are present
-	ad, _ := load.LoadStrategy(ctx, govTree, ballotName, false)
+	ad, _ := load.LoadStrategy(ctx, govTree, ballotName)
 
-	// verify ballot is not already frozen
-	if ad.Frozen {
-		must.Errorf(ctx, "ballot already frozen")
-	}
+	must.Assertf(ctx, !ad.Closed, "ballot is closed")
+	must.Assertf(ctx, !ad.Frozen, "ballot already frozen")
+
 	ad.Frozen = true
 
 	// write updated ad
-	openAdNS := common.OpenBallotNS(ballotName).Sub(common.AdFilebase)
+	openAdNS := common.BallotPath(ballotName).Sub(common.AdFilebase)
 	git.ToFileStage(ctx, govTree, openAdNS.Path(), ad)
 
 	return git.NewChangeNoResult(fmt.Sprintf("Freeze ballot %v", ballotName), "ballot_freeze")

--- a/proto/ballot/ballot/list.go
+++ b/proto/ballot/ballot/list.go
@@ -17,21 +17,15 @@ func List(
 	closed bool,
 ) []common.Advertisement {
 
-	return ListLocal(ctx, git.CloneOne(ctx, git.Address(govAddr)).Tree(), closed)
+	return ListLocal(ctx, git.CloneOne(ctx, git.Address(govAddr)).Tree())
 }
 
 func ListLocal(
 	ctx context.Context,
 	govTree *git.Tree,
-	closed bool,
 ) []common.Advertisement {
 
-	var ballotsNS ns.NS
-	if closed {
-		ballotsNS = common.ClosedBallotNS(ns.NS{})
-	} else {
-		ballotsNS = common.OpenBallotNS(ns.NS{})
-	}
+	ballotsNS := common.BallotPath(ns.NS{})
 
 	files, err := git.ListFilesRecursively(govTree, ballotsNS.Path())
 	must.NoError(ctx, err)

--- a/proto/ballot/ballot/show.go
+++ b/proto/ballot/ballot/show.go
@@ -11,14 +11,9 @@ import (
 	"github.com/gov4git/lib4git/ns"
 )
 
-func Show(
-	ctx context.Context,
-	govAddr gov.GovAddress,
-	ballotName ns.NS,
-	closed bool,
-) common.AdStrategyTally {
+func Show(ctx context.Context, govAddr gov.GovAddress, ballotName ns.NS) common.AdStrategyTally {
 
-	return ShowLocal(ctx, govAddr, git.CloneOne(ctx, git.Address(govAddr)).Tree(), ballotName, closed)
+	return ShowLocal(ctx, govAddr, git.CloneOne(ctx, git.Address(govAddr)).Tree(), ballotName)
 }
 
 func ShowLocal(
@@ -26,11 +21,10 @@ func ShowLocal(
 	govAddr gov.GovAddress,
 	govTree *git.Tree,
 	ballotName ns.NS,
-	closed bool,
 ) common.AdStrategyTally {
 
-	ad, strat := load.LoadStrategy(ctx, govTree, ballotName, closed)
+	ad, strat := load.LoadStrategy(ctx, govTree, ballotName)
 	var tally common.Tally
-	must.Try(func() { tally = LoadTally(ctx, govTree, ballotName, closed) })
+	must.Try(func() { tally = LoadTally(ctx, govTree, ballotName) })
 	return common.AdStrategyTally{Ad: ad, Strategy: strat, Tally: tally}
 }

--- a/proto/ballot/ballot/unfreeze.go
+++ b/proto/ballot/ballot/unfreeze.go
@@ -37,16 +37,15 @@ func UnfreezeStageOnly(
 	govTree := govCloned.Public.Tree()
 
 	// verify ad and strategy are present
-	ad, _ := load.LoadStrategy(ctx, govTree, ballotName, false)
+	ad, _ := load.LoadStrategy(ctx, govTree, ballotName)
 
-	// verify ballot is frozen
-	if !ad.Frozen {
-		must.Errorf(ctx, "ballot is not frozen")
-	}
+	must.Assertf(ctx, !ad.Closed, "ballot is closed")
+	must.Assertf(ctx, ad.Frozen, "ballot is not frozen")
+
 	ad.Frozen = false
 
 	// write updated ad
-	openAdNS := common.OpenBallotNS(ballotName).Sub(common.AdFilebase)
+	openAdNS := common.BallotPath(ballotName).Sub(common.AdFilebase)
 	git.ToFileStage(ctx, govTree, openAdNS.Path(), ad)
 
 	return git.NewChangeNoResult(fmt.Sprintf("Unfreeze ballot %v", ballotName), "ballot_unfreeze")

--- a/proto/ballot/ballot/vote.go
+++ b/proto/ballot/ballot/vote.go
@@ -42,12 +42,10 @@ func VoteStageOnly(
 	elections common.Elections,
 ) git.Change[form.Map, mail.SeqNo] {
 
-	ad, strat := load.LoadStrategy(ctx, govCloned.Tree(), ballotName, false)
+	ad, strat := load.LoadStrategy(ctx, govCloned.Tree(), ballotName)
 
-	// if the ballot is frozen, refuse to cast a vote
-	if ad.Frozen {
-		must.Errorf(ctx, "ballot is frozen")
-	}
+	must.Assertf(ctx, !ad.Closed, "ballot is closed")
+	must.Assertf(ctx, !ad.Frozen, "ballot is frozen")
 
 	verifyElections(ctx, strat, voterAddr, govAddr, voterOwner, govCloned, ad, elections)
 	envelope := common.VoteEnvelope{
@@ -85,7 +83,7 @@ func verifyElections(
 		}
 	}
 
-	tally := LoadTally(ctx, govCloned.Tree(), ad.Name, false)
+	tally := LoadTally(ctx, govCloned.Tree(), ad.Name)
 	strat.VerifyElections(ctx, voterAddr, govAddr, voterOwner, govCloned, &ad, &tally, elections)
 }
 

--- a/proto/ballot/common/schema.go
+++ b/proto/ballot/common/schema.go
@@ -19,16 +19,12 @@ var (
 	OutcomeFilebase  = "ballot_outcome.json"
 )
 
-func OpenBallotNS(name ns.NS) ns.NS {
-	return BallotNS.Sub("open").Join(name)
-}
-
-func ClosedBallotNS(name ns.NS) ns.NS {
-	return BallotNS.Sub("closed").Join(name)
-}
-
 func BallotTopic(name ns.NS) string {
 	return "ballot:" + name.Path()
+}
+
+func BallotPath(path ns.NS) ns.NS {
+	return BallotNS.Join(path)
 }
 
 type Advertisement struct {
@@ -40,6 +36,7 @@ type Advertisement struct {
 	Strategy     string         `json:"strategy"`
 	Participants member.Group   `json:"participants_group"`
 	Frozen       bool           `json:"frozen"` // if frozen, the ballot is not accepting votes
+	Closed       bool           `json:"closed"` // closed ballots cannot be re-opened
 	ParentCommit git.CommitHash `json:"parent_commit"`
 }
 

--- a/proto/ballot/common/util.go
+++ b/proto/ballot/common/util.go
@@ -7,3 +7,13 @@ func AdsToBallotNames(ads []Advertisement) []string {
 	}
 	return names
 }
+
+func FilterOpenClosedAds(closed bool, ads []Advertisement) []Advertisement {
+	r := []Advertisement{}
+	for _, ad := range ads {
+		if ad.Closed == closed {
+			r = append(r, ad)
+		}
+	}
+	return r
+}

--- a/proto/ballot/load/strats.go
+++ b/proto/ballot/load/strats.go
@@ -10,29 +10,14 @@ import (
 	"github.com/gov4git/lib4git/ns"
 )
 
-func LoadStrategy(
-	ctx context.Context,
-	govTree *git.Tree,
-	ballotName ns.NS,
-	closed bool,
-) (common.Advertisement, common.Strategy) {
+func LoadStrategy(ctx context.Context, govTree *git.Tree, ballotName ns.NS) (common.Advertisement, common.Strategy) {
 
 	// read ad
-	var adNS ns.NS
-	if closed {
-		adNS = common.ClosedBallotNS(ballotName).Sub(common.AdFilebase)
-	} else {
-		adNS = common.OpenBallotNS(ballotName).Sub(common.AdFilebase)
-	}
+	adNS := common.BallotPath(ballotName).Sub(common.AdFilebase)
 	ad := git.FromFile[common.Advertisement](ctx, govTree, adNS.Path())
 
 	// read strategy
-	var strategyNS ns.NS
-	if closed {
-		strategyNS = common.ClosedBallotNS(ballotName).Sub(common.StrategyFilebase)
-	} else {
-		strategyNS = common.OpenBallotNS(ballotName).Sub(common.StrategyFilebase)
-	}
+	strategyNS := common.BallotPath(ballotName).Sub(common.StrategyFilebase)
 	switch ad.Strategy {
 	case qv.QVStrategyName:
 		return ad, git.FromFile[qv.QV](ctx, govTree, strategyNS.Path())

--- a/test/api/testdata/script/ballot.txt
+++ b/test/api/testdata/script/ballot.txt
@@ -18,24 +18,24 @@ gov4git balance add --key voting_credits --user member1 --value 30.0
 # ballot
 
 gov4git ballot open --name ballot_1/xyz --title 'Ballot 1' --desc 'Description 1' --group everybody --choices 'choice-1'
-gov4git ballot list-open
+gov4git ballot list
 stdout ballot_1
 
 gov4git ballot vote --name ballot_1/xyz --choices choice-1 --strengths 9.0
 gov4git ballot tally --name ballot_1/xyz
 
-gov4git ballot show-open --name ballot_1/xyz
+gov4git ballot show --name ballot_1/xyz
 stdout '"score": 3'
 
 gov4git ballot vote --name ballot_1/xyz --choices choice-1 --strengths 7.0
 gov4git sync
 
-gov4git ballot show-open --name ballot_1/xyz
+gov4git ballot show --name ballot_1/xyz
 stdout '"score": 4'
 
 gov4git ballot close --name ballot_1/xyz
-gov4git ballot list-closed
+gov4git ballot list
 stdout ballot_1
 
-gov4git ballot show-closed --name ballot_1/xyz
+gov4git ballot show --name ballot_1/xyz
 stdout '"score": 4'

--- a/test/ballot/ballot_test.go
+++ b/test/ballot/ballot_test.go
@@ -184,11 +184,11 @@ func TestTallyAll(t *testing.T) {
 	fmt.Println("tally: ", form.SprintJSON(tallyChg))
 
 	// verify tallies are correct
-	ast0 := ballot.Show(ctx, cty.Gov(), ballotName0, false)
+	ast0 := ballot.Show(ctx, cty.Gov(), ballotName0)
 	if ast0.Tally.Scores[choices[0]] != math.Sqrt(5.0) {
 		t.Errorf("expecting %v, got %v", math.Sqrt(5.0), ast0.Tally.Scores[choices[0]])
 	}
-	ast1 := ballot.Show(ctx, cty.Gov(), ballotName1, false)
+	ast1 := ballot.Show(ctx, cty.Gov(), ballotName1)
 	if ast1.Tally.Scores[choices[0]] != -math.Sqrt(5.0) {
 		t.Errorf("expecting %v, got %v", -math.Sqrt(5.0), ast1.Tally.Scores[choices[0]])
 	}

--- a/test/sync/sync_test.go
+++ b/test/sync/sync_test.go
@@ -49,11 +49,11 @@ func TestSync(t *testing.T) {
 	fmt.Println("sync: ", form.SprintJSON(syncChg))
 
 	// verify tallies are correct
-	ast0 := ballot.Show(ctx, cty.Gov(), ballotName0, false)
+	ast0 := ballot.Show(ctx, cty.Gov(), ballotName0)
 	if ast0.Tally.Scores[choices[0]] != math.Sqrt(5.0) {
 		t.Errorf("expecting %v, got %v", math.Sqrt(5.0), ast0.Tally.Scores[choices[0]])
 	}
-	ast1 := ballot.Show(ctx, cty.Gov(), ballotName1, false)
+	ast1 := ballot.Show(ctx, cty.Gov(), ballotName1)
 	if ast1.Tally.Scores[choices[0]] != -math.Sqrt(5.0) {
 		t.Errorf("expecting %v, got %v", -math.Sqrt(5.0), ast1.Tally.Scores[choices[0]])
 	}


### PR DESCRIPTION
- add closure flag to ballot advertisement
- save all ballots, regardless of state, in the same filesystem namespace
- drop `ballot list-open` and `ballot list-closed` in favor of `ballot list`
- drop `ballot show-open` and `ballot show-closed` in favor of `ballot show`

Resolves https://github.com/gov4git/gov4git/issues/56