### PR TITLE
track votes end-to-end

### DIFF
--- a/NOTES.txt
+++ b/NOTES.txt
@@ -1,9 +1,7 @@
-
+- [x] test
 - [ ] (receiver id + ballot topic) is used to identify the receiver
 	- what happens if a malicious receiver picks the same ID as someone else
 		- [ ] make id = hash of public key
 	- this question applies to vote logging as well
 	- applies also when determining a user's name within the community, based on public credentials
 
-- [ ] address XXX
-- [x] test

--- a/NOTES.txt
+++ b/NOTES.txt
@@ -1,0 +1,5 @@
+
+
+- (receiver id + ballot topic) is used to identify the receiver
+	- what happens if a malicious receiver picks the same ID as someone else
+	- this question applies to vote logging as well

--- a/NOTES.txt
+++ b/NOTES.txt
@@ -6,4 +6,4 @@
 	- applies also when determining a user's name within the community, based on public credentials
 
 - [ ] address XXX
-- [ ] test
+- [x] test

--- a/NOTES.txt
+++ b/NOTES.txt
@@ -1,5 +1,9 @@
 
-
-- (receiver id + ballot topic) is used to identify the receiver
+- [ ] (receiver id + ballot topic) is used to identify the receiver
 	- what happens if a malicious receiver picks the same ID as someone else
+		- [ ] make id = hash of public key
 	- this question applies to vote logging as well
+	- applies also when determining a user's name within the community, based on public credentials
+
+- [ ] address XXX
+- [ ] test

--- a/NOTES.txt
+++ b/NOTES.txt
@@ -1,7 +1,0 @@
-- [x] test
-- [ ] (receiver id + ballot topic) is used to identify the receiver
-	- what happens if a malicious receiver picks the same ID as someone else
-		- [ ] make id = hash of public key
-	- this question applies to vote logging as well
-	- applies also when determining a user's name within the community, based on public credentials
-

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/gov4git/gov4git
 go 1.19
 
 require (
-	github.com/google/uuid v1.3.0
 	github.com/gov4git/lib4git v0.0.17
 	github.com/gov4git/vendor4git v0.0.1
 	github.com/rogpeppe/go-internal v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gov4git/gov4git
 go 1.19
 
 require (
-	github.com/gov4git/lib4git v0.0.17
+	github.com/gov4git/lib4git v0.0.18
 	github.com/gov4git/vendor4git v0.0.1
 	github.com/rogpeppe/go-internal v1.11.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,6 @@ github.com/google/go-github/v53 v53.2.0 h1:wvz3FyF53v4BK+AsnvCmeNhf8AkTaeh2SoYu/
 github.com/google/go-github/v53 v53.2.0/go.mod h1:XhFRObz+m/l+UCm9b7KSIC3lT3NWSXGt7mOsAWEloao=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gov4git/lib4git v0.0.17 h1:7ckZ6HEZIqcwY26PtckqObEmi8ZYdPgcPnDkgC3HoYs=
 github.com/gov4git/lib4git v0.0.17/go.mod h1:bXL67JOVTyh/5FkF5HyabaMk5BxAC08GYbqTjVyrY18=
 github.com/gov4git/vendor4git v0.0.1 h1:iB9vHqSdjjCDAHnyfDaA+VIY3OZQYJ5bLvApsdL4L0I=

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/google/go-github/v53 v53.2.0 h1:wvz3FyF53v4BK+AsnvCmeNhf8AkTaeh2SoYu/
 github.com/google/go-github/v53 v53.2.0/go.mod h1:XhFRObz+m/l+UCm9b7KSIC3lT3NWSXGt7mOsAWEloao=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
-github.com/gov4git/lib4git v0.0.17 h1:7ckZ6HEZIqcwY26PtckqObEmi8ZYdPgcPnDkgC3HoYs=
-github.com/gov4git/lib4git v0.0.17/go.mod h1:bXL67JOVTyh/5FkF5HyabaMk5BxAC08GYbqTjVyrY18=
+github.com/gov4git/lib4git v0.0.18 h1:KffNODl/CSf5dtsOgfBRV+vXHbyY7S8Ghbtx3aVcfA4=
+github.com/gov4git/lib4git v0.0.18/go.mod h1:bXL67JOVTyh/5FkF5HyabaMk5BxAC08GYbqTjVyrY18=
 github.com/gov4git/vendor4git v0.0.1 h1:iB9vHqSdjjCDAHnyfDaA+VIY3OZQYJ5bLvApsdL4L0I=
 github.com/gov4git/vendor4git v0.0.1/go.mod h1:zceIOhS5G21y1FZxyLquUP3AqBuOT+M99uk6IexYlL0=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=

--- a/gov4git/cmd/ballot.go
+++ b/gov4git/cmd/ballot.go
@@ -160,6 +160,25 @@ var (
 			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
+
+	ballotTrackCmd = &cobra.Command{
+		Use:   "track",
+		Short: "Track the status of votes",
+		Long: `Track reports on the status of the user's votes on a given ballot.
+It returns a report listing accepted, rejected and pending votes.
+Rejected votes are associated with a reason, such as "ballot is frozen".
+Pending votes have not yet been processed by the community's governance.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			LoadConfig()
+			status := ballot.Track(
+				ctx,
+				setup.Member,
+				setup.Gov,
+				ns.ParseFromPath(ballotName),
+			)
+			fmt.Fprint(os.Stdout, form.SprintJSON(status))
+		},
+	}
 )
 
 var (
@@ -236,6 +255,11 @@ func init() {
 	ballotVoteCmd.MarkFlagRequired("choices")
 	ballotVoteCmd.Flags().Float64SliceVar(&ballotElectionStrength, "strengths", nil, "list of elected vote strengths")
 	ballotVoteCmd.MarkFlagRequired("strengths")
+
+	// track
+	ballotCmd.AddCommand(ballotTrackCmd)
+	ballotTrackCmd.Flags().StringVar(&ballotName, "name", "", "ballot name")
+	ballotTrackCmd.MarkFlagRequired("name")
 }
 
 func parseElections(ctx context.Context, choices []string, strengths []float64) common.Elections {

--- a/proto/ballot/ballot/tally.go
+++ b/proto/ballot/ballot/tally.go
@@ -138,5 +138,4 @@ func rejectFetchedVotes(fv FetchedVotes, rej map[member.User]common.RejectedElec
 
 func LoadTally(ctx context.Context, communityTree *git.Tree, ballotName ns.NS) common.Tally {
 	tallyNS := common.BallotPath(ballotName).Sub(common.TallyFilebase)
-	return git.FromFile[common.Tally](ctx, communityTree, tallyNS.Path())
-}
+	return git.FromFile[common.Tally](ctx, communityTree, tallyNS.Path()) }

--- a/proto/ballot/ballot/track.go
+++ b/proto/ballot/ballot/track.go
@@ -1,0 +1,52 @@
+package ballot
+
+import (
+	"context"
+
+	"github.com/gov4git/gov4git/proto/ballot/common"
+	"github.com/gov4git/gov4git/proto/gov"
+	"github.com/gov4git/gov4git/proto/id"
+	"github.com/gov4git/gov4git/proto/member"
+	"github.com/gov4git/lib4git/git"
+	"github.com/gov4git/lib4git/must"
+	"github.com/gov4git/lib4git/ns"
+)
+
+func Track(
+	ctx context.Context,
+	voterAddr id.OwnerAddress,
+	govAddr gov.GovAddress,
+	ballotName ns.NS,
+) common.VoterStatus {
+
+	govCloned := git.CloneOne(ctx, git.Address(govAddr))
+	voterOwner := id.CloneOwner(ctx, voterAddr)
+	return TrackStageOnly(ctx, voterAddr, govAddr, voterOwner, govCloned, ballotName)
+}
+
+func TrackStageOnly(
+	ctx context.Context,
+	voterAddr id.OwnerAddress,
+	govAddr gov.GovAddress,
+	voterOwner id.OwnerCloned,
+	govCloned git.Cloned,
+	ballotName ns.NS,
+) common.VoterStatus {
+
+	// determine the voter's username in the community
+	voterCred := id.GetPublicCredentials(ctx, voterOwner.Public.Tree())
+	user := member.LookupUserByIDLocal(ctx, govCloned.Tree(), voterCred.ID)
+	must.Assertf(ctx, len(user) > 0, "user not found in community")
+
+	// read the ballot tally
+	tally := LoadTally(ctx, govCloned.Tree(), ballotName)
+
+	// read the voter's log
+	govCred := id.GetPublicCredentials(ctx, govCloned.Tree())
+	voteLogNS := common.VoteLogPath(govCred.ID, ballotName)
+	voteLog := git.FromFile[common.VoteLog](ctx, voterOwner.Public.Tree(), voteLogNS.Path())
+
+	XXX
+
+	return common.VoterStatus{XXX}
+}

--- a/proto/ballot/ballot/vote.go
+++ b/proto/ballot/ballot/vote.go
@@ -60,7 +60,7 @@ func VoteStageOnly(
 	voteLogNS := common.VoteLogPath(govCred.ID, ballotName)
 	// read current vote log
 	voteLog, err := git.TryFromFile[common.VoteLog](ctx, voterTree, voteLogNS.Path())
-	if err != nil {
+	if err != nil { // XXX: isolate file not found error only
 		voteLog = common.VoteLog{
 			GovID:         govCred.ID,
 			GovAddress:    govAddr,

--- a/proto/ballot/ballot/vote.go
+++ b/proto/ballot/ballot/vote.go
@@ -60,13 +60,15 @@ func VoteStageOnly(
 	voteLogNS := common.VoteLogPath(govCred.ID, ballotName)
 	// read current vote log
 	voteLog, err := git.TryFromFile[common.VoteLog](ctx, voterTree, voteLogNS.Path())
-	if err != nil { // XXX: isolate file not found error only
+	if git.IsNotExist(err) {
 		voteLog = common.VoteLog{
 			GovID:         govCred.ID,
 			GovAddress:    govAddr,
 			Ballot:        ballotName,
 			VoteEnvelopes: nil,
 		}
+	} else {
+		must.NoError(ctx, err)
 	}
 	// append new vote
 	voteLog.VoteEnvelopes = append(voteLog.VoteEnvelopes, envelope)

--- a/proto/ballot/common/schema.go
+++ b/proto/ballot/common/schema.go
@@ -36,7 +36,7 @@ type VoteLog struct {
 type VoterStatus struct {
 	GovID         id.ID             `json:"governance_id"`
 	GovAddress    gov.GovAddress    `json:"governance_address"`
-	Ballot        ns.NS             `json:"ballot_name"`
+	BallotName    ns.NS             `json:"ballot_name"`
 	AcceptedVotes AcceptedElections `json:"accepted_votes"`
 	RejectedVotes RejectedElections `json:"rejected_votes"`
 	PendingVotes  Elections         `json:"pending_votes"`

--- a/proto/ballot/common/schema.go
+++ b/proto/ballot/common/schema.go
@@ -32,6 +32,16 @@ type VoteLog struct {
 	VoteEnvelopes VoteEnvelopes  `json:"vote_envelopes"` // in the order in which they were sent
 }
 
+// VoterStatus reflects the state of an individual user's votes within a ballot.
+type VoterStatus struct {
+	GovID         id.ID             `json:"governance_id"`
+	GovAddress    gov.GovAddress    `json:"governance_address"`
+	Ballot        ns.NS             `json:"ballot_name"`
+	AcceptedVotes AcceptedElections `json:"accepted_votes"`
+	RejectedVotes RejectedElections `json:"rejected_votes"`
+	PendingVotes  Elections         `json:"pending_votes"`
+}
+
 func VoteLogPath(govID id.ID, ballotName ns.NS) ns.NS {
 	return VoteLogNS.Sub(
 		filepath.Join(

--- a/proto/ballot/common/schema.go
+++ b/proto/ballot/common/schema.go
@@ -87,7 +87,7 @@ type Election struct {
 
 func NewElection(choice string, strength float64) Election {
 	return Election{
-		VoteID:             id.GenerateUniqueID(),
+		VoteID:             id.GenerateUniqueID(), //XXX
 		VoteTime:           time.Now(),
 		VoteChoice:         choice,
 		VoteStrengthChange: strength,

--- a/proto/ballot/common/schema.go
+++ b/proto/ballot/common/schema.go
@@ -1,11 +1,14 @@
 package common
 
 import (
+	"path/filepath"
 	"time"
 
 	"github.com/gov4git/gov4git/proto"
 	"github.com/gov4git/gov4git/proto/gov"
+	"github.com/gov4git/gov4git/proto/id"
 	"github.com/gov4git/gov4git/proto/member"
+	"github.com/gov4git/lib4git/form"
 	"github.com/gov4git/lib4git/git"
 	"github.com/gov4git/lib4git/ns"
 	"github.com/gov4git/lib4git/util"
@@ -17,10 +20,29 @@ var (
 	StrategyFilebase = "ballot_strategy.json"
 	TallyFilebase    = "ballot_tally.json"
 	OutcomeFilebase  = "ballot_outcome.json"
+
+	VoteLogNS = proto.RootNS.Sub("votes") // namespace in voter's repo for recording votes
 )
 
-func BallotTopic(name ns.NS) string {
-	return "ballot:" + name.Path()
+// VoteLog records the votes of a user to a ballot within a given governance.
+type VoteLog struct {
+	GovID         id.ID          `json:"governance_id"`
+	GovAddress    gov.GovAddress `json:"governance_address"`
+	Ballot        ns.NS          `json:"ballot_name"`
+	VoteEnvelopes VoteEnvelopes  `json:"vote_envelopes"` // in the order in which they were sent
+}
+
+func VoteLogPath(govID id.ID, ballotName ns.NS) ns.NS {
+	return VoteLogNS.Sub(
+		filepath.Join(
+			form.StringHashForFilename(string(govID)),
+			form.StringHashForFilename(BallotTopic(ballotName)),
+		),
+	)
+}
+
+func BallotTopic(ballotName ns.NS) string {
+	return "ballot:" + ballotName.Path()
 }
 
 func BallotPath(path ns.NS) ns.NS {
@@ -47,13 +69,19 @@ type BallotAddress struct {
 }
 
 type Election struct {
+	VoteID             id.ID     `json:"vote_id"`
 	VoteTime           time.Time `json:"vote_time"`
 	VoteChoice         string    `json:"vote_choice"`
 	VoteStrengthChange float64   `json:"vote_strength_change"`
 }
 
 func NewElection(choice string, strength float64) Election {
-	return Election{VoteTime: time.Now(), VoteChoice: choice, VoteStrengthChange: strength}
+	return Election{
+		VoteID:             id.GenerateUniqueID(),
+		VoteTime:           time.Now(),
+		VoteChoice:         choice,
+		VoteStrengthChange: strength,
+	}
 }
 
 type Elections []Election
@@ -63,6 +91,8 @@ type VoteEnvelope struct {
 	Ad        Advertisement  `json:"ballot_ad"`
 	Elections Elections      `json:"ballot_elections"`
 }
+
+type VoteEnvelopes []VoteEnvelope
 
 // Verify verifies that elections are consistent with the ballot ad.
 func (x VoteEnvelope) VerifyConsistency() bool {

--- a/proto/ballot/common/schema.go
+++ b/proto/ballot/common/schema.go
@@ -87,7 +87,7 @@ type Election struct {
 
 func NewElection(choice string, strength float64) Election {
 	return Election{
-		VoteID:             id.GenerateUniqueID(), //XXX
+		VoteID:             id.GenerateRandomID(),
 		VoteTime:           time.Now(),
 		VoteChoice:         choice,
 		VoteStrengthChange: strength,

--- a/proto/id/crypto.go
+++ b/proto/id/crypto.go
@@ -20,7 +20,7 @@ func GenerateCredentials() (PrivateCredentials, error) {
 	return PrivateCredentials{
 		PrivateKeyEd25519: Ed25519PrivateKey(privKey),
 		PublicCredentials: PublicCredentials{
-			ID:               GenerateUniqueID(),
+			ID:               Ed25519PubKeyToID(pubKey),
 			PublicKeyEd25519: Ed25519PublicKey(pubKey),
 		},
 	}, nil

--- a/proto/id/private.go
+++ b/proto/id/private.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gov4git/lib4git/form"
 	"github.com/gov4git/lib4git/git"
+	"github.com/gov4git/lib4git/must"
 )
 
 func FetchOwnerCredentials(ctx context.Context, addr OwnerAddress) PrivateCredentials {
@@ -16,5 +17,7 @@ func GetOwnerCredentials(ctx context.Context, owner OwnerCloned) PrivateCredenti
 }
 
 func GetPrivateCredentials(ctx context.Context, privateTree *git.Tree) PrivateCredentials {
-	return form.FromFile[PrivateCredentials](ctx, privateTree.Filesystem, PrivateCredentialsNS.Path())
+	cred := form.FromFile[PrivateCredentials](ctx, privateTree.Filesystem, PrivateCredentialsNS.Path())
+	must.Assertf(ctx, cred.IsValid(), "credentials are not valid")
+	return cred
 }

--- a/proto/id/public.go
+++ b/proto/id/public.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gov4git/lib4git/form"
 	"github.com/gov4git/lib4git/git"
+	"github.com/gov4git/lib4git/must"
 )
 
 func FetchPublicCredentials(ctx context.Context, addr PublicAddress) PublicCredentials {
@@ -12,5 +13,7 @@ func FetchPublicCredentials(ctx context.Context, addr PublicAddress) PublicCrede
 }
 
 func GetPublicCredentials(ctx context.Context, t *git.Tree) PublicCredentials {
-	return form.FromFile[PublicCredentials](ctx, t.Filesystem, PublicCredentialsNS.Path())
+	cred := form.FromFile[PublicCredentials](ctx, t.Filesystem, PublicCredentialsNS.Path())
+	must.Assertf(ctx, cred.IsValid(), "credentials are not valid")
+	return cred
 }

--- a/proto/id/schema.go
+++ b/proto/id/schema.go
@@ -2,8 +2,8 @@ package id
 
 import (
 	"crypto/ed25519"
+	"crypto/rand"
 
-	"github.com/google/uuid"
 	"github.com/gov4git/gov4git/proto"
 	"github.com/gov4git/lib4git/form"
 )
@@ -20,8 +20,11 @@ var (
 
 type ID string
 
-func GenerateUniqueID() ID {
-	return ID(uuid.New().String())
+func GenerateRandomID() ID {
+	const w = 512 / 8 // 512 bits, measured in bytes
+	buf := make([]byte, w)
+	rand.Read(buf)
+	return ID(form.BytesHashForFilename(buf))
 }
 
 type PublicCredentials struct {

--- a/proto/id/schema.go
+++ b/proto/id/schema.go
@@ -1,8 +1,11 @@
 package id
 
 import (
+	"crypto/ed25519"
+
 	"github.com/google/uuid"
 	"github.com/gov4git/gov4git/proto"
+	"github.com/gov4git/lib4git/form"
 )
 
 var (
@@ -26,7 +29,19 @@ type PublicCredentials struct {
 	PublicKeyEd25519 Ed25519PublicKey `json:"public_key_ed25519"`
 }
 
+func Ed25519PubKeyToID(pubKey ed25519.PublicKey) ID {
+	return ID(form.BytesHashForFilename(pubKey))
+}
+
+func (x PublicCredentials) IsValid() bool {
+	return form.BytesHashForFilename(x.PublicKeyEd25519) == string(x.ID)
+}
+
 type PrivateCredentials struct {
 	PrivateKeyEd25519 Ed25519PrivateKey `json:"private_key_ed25519"`
 	PublicCredentials PublicCredentials `json:"public_credentials"`
+}
+
+func (x PrivateCredentials) IsValid() bool {
+	return x.PublicCredentials.IsValid()
 }

--- a/test/api/testdata/script/track.txt
+++ b/test/api/testdata/script/track.txt
@@ -1,0 +1,30 @@
+provision # community and one user
+
+# init-id
+
+gov4git init-gov
+stdout private_key_ed25519
+
+# init-gov
+
+gov4git init-id
+stdout private_key_ed25519
+
+# add user and balance
+
+gov4git user add --name member1 --repo ~/member_public --branch main
+gov4git balance add --key voting_credits --user member1 --value 6.0
+
+# ballot
+
+gov4git ballot open --name ballot_1/xyz --title 'Ballot 1' --desc 'Description 1' --group everybody --choices 'choice-1'
+gov4git ballot vote --name ballot_1/xyz --choices choice-1 --strengths 1.0
+gov4git ballot tally --name ballot_1/xyz
+gov4git ballot vote --name ballot_1/xyz --choices choice-1 --strengths 2.0
+gov4git ballot freeze --name ballot_1/xyz
+gov4git ballot tally --name ballot_1/xyz
+gov4git ballot unfreeze --name ballot_1/xyz
+gov4git ballot vote --name ballot_1/xyz --choices choice-1 --strengths 3.0
+gov4git ballot track --name ballot_1/xyz
+stdout accepted_vote
+stdout rejected_vote

--- a/test/ballot/track_test.go
+++ b/test/ballot/track_test.go
@@ -1,0 +1,68 @@
+package ballot
+
+import (
+	"testing"
+
+	"github.com/gov4git/gov4git/proto/balance"
+	"github.com/gov4git/gov4git/proto/ballot/ballot"
+	"github.com/gov4git/gov4git/proto/ballot/common"
+	"github.com/gov4git/gov4git/proto/ballot/qv"
+	"github.com/gov4git/gov4git/proto/member"
+	"github.com/gov4git/gov4git/test"
+	"github.com/gov4git/lib4git/form"
+	"github.com/gov4git/lib4git/ns"
+	"github.com/gov4git/lib4git/testutil"
+)
+
+func TestTrack(t *testing.T) {
+
+	ctx := testutil.NewCtx()
+	cty := test.NewTestCommunity(t, ctx, 2)
+
+	ballotName := ns.NS{"a", "b", "c"}
+	choices := []string{"x", "y", "z"}
+
+	// give voter credits
+	balance.Set(ctx, cty.Gov(), cty.MemberUser(0), qv.VotingCredits, 6.0)
+
+	// open ballot
+	ballot.Open(ctx, qv.QV{}, cty.Gov(), ballotName, "ballot title", "ballot description", choices, member.Everybody)
+
+	// vote 1: accepted vote
+	elections1 := common.Elections{common.NewElection(choices[0], 1.0)}
+	ballot.Vote(ctx, cty.MemberOwner(0), cty.Gov(), ballotName, elections1)
+
+	// tally: collect and accept first vote
+	ballot.Tally(ctx, cty.Organizer(), ballotName)
+
+	// vote 2: rejected vote
+	elections2 := common.Elections{common.NewElection(choices[0], 2.0)}
+	ballot.Vote(ctx, cty.MemberOwner(0), cty.Gov(), ballotName, elections2)
+
+	// freeze ballot
+	ballot.Freeze(ctx, cty.Organizer(), ballotName)
+
+	// tally: collect and reject second vote (because ballot is frozen)
+	ballot.Tally(ctx, cty.Organizer(), ballotName)
+
+	// unfreeze ballot
+	ballot.Unfreeze(ctx, cty.Organizer(), ballotName)
+
+	// vote 3: pending vote (never tallied)
+	elections3 := common.Elections{common.NewElection(choices[0], 3.0)}
+	ballot.Vote(ctx, cty.MemberOwner(0), cty.Gov(), ballotName, elections3)
+
+	// track
+	status := ballot.Track(ctx, cty.MemberOwner(0), cty.Gov(), ballotName)
+	if len(status.AcceptedVotes) != 1 || status.AcceptedVotes[0].Vote.VoteStrengthChange != 1.0 {
+		t.Errorf("expecting one accepted vote with strength 1.0, got %v", form.SprintJSON(status))
+	}
+	if len(status.RejectedVotes) != 1 || status.RejectedVotes[0].Vote.VoteStrengthChange != 2.0 {
+		t.Errorf("expecting one rejected vote with strength 2.0, got %v", form.SprintJSON(status))
+	}
+	if len(status.PendingVotes) != 1 || status.PendingVotes[0].VoteStrengthChange != 3.0 {
+		t.Errorf("expecting one pending vote with strength 3.0, got %v", form.SprintJSON(status))
+	}
+
+	// testutil.Hang()
+}


### PR DESCRIPTION
- add `ballot track` command which reports on the state of user's votes with respect to a ballot
- adopt protocol requirement that user id's are computed as a hash of their public keys

Resolves https://github.com/gov4git/gov4git/issues/58