### PR TITLE
multiprocess reentrant cache with prefetching and per-repo ttl

### DIFF
--- a/doc/walkthrough.sh
+++ b/doc/walkthrough.sh
@@ -32,6 +32,8 @@ go install github.com/gov4git/gov4git/gov4git@latest
 
 cat <<EOF >> ~/.gov4git/config
 {
+     "cache_dir": "/Users/petar/.gov4git/cache",
+     "cache_ttl_seconds": 120,
      "auth" : {
           "git@github.com:petar/community.public.git": { "ssh_private_keys_file": "/Users/petar/.ssh/id_rsa" },
           "git@github.com:petar/community.private.git": { "ssh_private_keys_file": "/Users/petar/.ssh/id_rsa" },
@@ -49,6 +51,8 @@ cat <<EOF >> ~/.gov4git/config
 }
 EOF
 
+# `cache_dir`, if specified, sets the on-disk location for local caches of remote repos
+# `cache_ttl_seconds` sets the ttl for cached replicas of community and member repos
 # `ssh_private_keys_file` points to a local file containing your SSH credentials for cloning the private repos in the config.
 # `community_public_url` is the git URL of the public community repo
 # `community_public_branch` is the branch in the public community repo where the governance state will reside
@@ -66,6 +70,8 @@ EOF
 
 cat <<EOF >> ~/.gov4git/config
 {
+     "cache_dir": "/Users/petar/.gov4git/cache",
+     "cache_ttl_seconds": 120,
      "auth" : {
           "https://github.com/petar/community.public.git": { "access_token": "YOUR_ACCESS_TOKEN" },
           "https://github.com/petar/community.private.git": { "access_token": "YOUR_ACCESS_TOKEN" },

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gov4git/gov4git
 go 1.19
 
 require (
-	github.com/gov4git/lib4git v0.0.19
+	github.com/gov4git/lib4git v0.0.20
 	github.com/gov4git/vendor4git v0.0.1
 	github.com/rogpeppe/go-internal v1.11.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/google/go-github/v53 v53.2.0 h1:wvz3FyF53v4BK+AsnvCmeNhf8AkTaeh2SoYu/
 github.com/google/go-github/v53 v53.2.0/go.mod h1:XhFRObz+m/l+UCm9b7KSIC3lT3NWSXGt7mOsAWEloao=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
-github.com/gov4git/lib4git v0.0.19 h1:Xox8SbtmqWcCULvY6ul5wqa2fkqnAqY0rJIiik3Av3U=
-github.com/gov4git/lib4git v0.0.19/go.mod h1:bXL67JOVTyh/5FkF5HyabaMk5BxAC08GYbqTjVyrY18=
+github.com/gov4git/lib4git v0.0.20 h1:sM/WJeXWs5gWWdEUz63FjHqrD9cjRd3en+Dsc0NRbQs=
+github.com/gov4git/lib4git v0.0.20/go.mod h1:bXL67JOVTyh/5FkF5HyabaMk5BxAC08GYbqTjVyrY18=
 github.com/gov4git/vendor4git v0.0.1 h1:iB9vHqSdjjCDAHnyfDaA+VIY3OZQYJ5bLvApsdL4L0I=
 github.com/gov4git/vendor4git v0.0.1/go.mod h1:zceIOhS5G21y1FZxyLquUP3AqBuOT+M99uk6IexYlL0=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=

--- a/gov4git/cmd/cache.go
+++ b/gov4git/cmd/cache.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/gov4git/lib4git/base"
+	lib4git "github.com/gov4git/lib4git/git"
+	"github.com/gov4git/lib4git/must"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cacheCmd = &cobra.Command{
+		Use:   "cache",
+		Short: "Manage local client cache",
+		Long:  ``,
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+
+	cacheClearCmd = &cobra.Command{
+		Use:   "clear",
+		Short: "Clear local client cache",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			LoadConfig()
+			must.Assertf(ctx, setup.CacheDir != "", "cache dir not specified in config")
+			err := os.RemoveAll(setup.CacheDir)
+			must.NoError(ctx, err)
+		},
+	}
+
+	cacheUpdateCmd = &cobra.Command{
+		Use:   "update",
+		Short: "Update local cache by prefetching community and user repos",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			LoadConfig()
+			if cacheUpdateIntervalSeconds > 0 {
+				for {
+					updateCacheBestEffort(ctx)
+					time.Sleep(time.Second * time.Duration(cacheUpdateIntervalSeconds))
+				}
+			} else {
+				updateCacheBestEffort(ctx)
+			}
+		},
+	}
+)
+
+func updateCacheBestEffort(ctx context.Context) {
+	updateCacheReplicaBestEffort(ctx, lib4git.Address(setup.Gov))
+	updateCacheReplicaBestEffort(ctx, lib4git.Address(setup.Organizer.Public))
+	updateCacheReplicaBestEffort(ctx, lib4git.Address(setup.Organizer.Private))
+	updateCacheReplicaBestEffort(ctx, lib4git.Address(setup.Member.Public))
+	updateCacheReplicaBestEffort(ctx, lib4git.Address(setup.Member.Private))
+}
+
+func updateCacheReplicaBestEffort(ctx context.Context, addr lib4git.Address) {
+	if err := must.Try(func() { lib4git.CloneOne(ctx, addr) }); err != nil {
+		base.Infof("best effort cache update for %v failed (%v)", addr, err)
+	}
+}
+
+var (
+	cacheUpdateIntervalSeconds int
+)
+
+func init() {
+	cacheCmd.AddCommand(cacheClearCmd)
+
+	cacheCmd.AddCommand(cacheUpdateCmd)
+	cacheUpdateCmd.Flags().IntVar(&cacheUpdateIntervalSeconds, "seconds", 0, "update cache every N seconds, if set")
+}

--- a/gov4git/cmd/cache.go
+++ b/gov4git/cmd/cache.go
@@ -14,7 +14,7 @@ import (
 var (
 	cacheCmd = &cobra.Command{
 		Use:   "cache",
-		Short: "Manage local client cache",
+		Short: "Manage the client's local cache",
 		Long:  ``,
 		Run:   func(cmd *cobra.Command, args []string) {},
 	}
@@ -37,6 +37,7 @@ var (
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
 			LoadConfig()
+			must.Assertf(ctx, setup.CacheDir != "", "cache dir not specified in config")
 			if cacheUpdateIntervalSeconds > 0 {
 				for {
 					updateCacheBestEffort(ctx)

--- a/gov4git/cmd/proto.go
+++ b/gov4git/cmd/proto.go
@@ -14,6 +14,7 @@ const (
 )
 
 type Setup struct {
+	CacheDir  string
 	Gov       gov.GovAddress
 	Organizer gov.OrganizerAddress
 	Member    id.OwnerAddress
@@ -48,7 +49,7 @@ type UserPassword struct {
 
 func (cfg Config) Setup(ctx context.Context) Setup {
 
-	git.SetAuthor("gov4git governance", "no-reply@gov4git.xyz")
+	git.SetAuthor("gov4git governance", "no-reply@gov4git")
 
 	for url, auth := range cfg.Auth {
 		switch {
@@ -62,7 +63,8 @@ func (cfg Config) Setup(ctx context.Context) Setup {
 	}
 
 	return Setup{
-		Gov: gov.GovAddress{Repo: cfg.GovPublicURL, Branch: cfg.GovPublicBranch},
+		CacheDir: cfg.CacheDir,
+		Gov:      gov.GovAddress{Repo: cfg.GovPublicURL, Branch: cfg.GovPublicBranch},
 		Organizer: gov.OrganizerAddress{
 			Public:  id.PublicAddress{Repo: cfg.GovPublicURL, Branch: cfg.GovPublicBranch},
 			Private: id.PrivateAddress{Repo: cfg.GovPrivateURL, Branch: cfg.GovPrivateBranch},

--- a/gov4git/cmd/root.go
+++ b/gov4git/cmd/root.go
@@ -83,7 +83,7 @@ func LoadConfig() {
 	}
 
 	if config.CacheDir != "" {
-		git.UseCache(ctx, config.CacheDir)
+		ctx = git.WithCache(ctx, config.CacheDir)
 	}
 
 	setup = config.Setup(ctx)

--- a/gov4git/cmd/root.go
+++ b/gov4git/cmd/root.go
@@ -22,7 +22,7 @@ var (
 	}
 )
 
-var ctx = git.WithAuth(context.Background(), nil)
+var ctx = git.WithTTL(git.WithAuth(context.Background(), nil), nil)
 
 var (
 	configPath string
@@ -48,6 +48,7 @@ func init() {
 	rootCmd.AddCommand(vendorCmd)
 	rootCmd.AddCommand(syncCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(cacheCmd)
 }
 
 func initAfterFlags() {

--- a/gov4git/cmd/root.go
+++ b/gov4git/cmd/root.go
@@ -15,7 +15,7 @@ import (
 var (
 	rootCmd = &cobra.Command{
 		Use:   "gov4git",
-		Short: "gov4git is a command-line client for transparent community governance",
+		Short: "gov4git is a command-line client for the gov4git community governance protocol",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
 		},

--- a/proto/ballot/ballot/tally.go
+++ b/proto/ballot/ballot/tally.go
@@ -138,4 +138,5 @@ func rejectFetchedVotes(fv FetchedVotes, rej map[member.User]common.RejectedElec
 
 func LoadTally(ctx context.Context, communityTree *git.Tree, ballotName ns.NS) common.Tally {
 	tallyNS := common.BallotPath(ballotName).Sub(common.TallyFilebase)
-	return git.FromFile[common.Tally](ctx, communityTree, tallyNS.Path()) }
+	return git.FromFile[common.Tally](ctx, communityTree, tallyNS.Path())
+}


### PR DESCRIPTION
- cloning is fully reeantrant across processes
- add `gov4git cache clear` command: wipe clean the local repo cache
- add `gov4git cache update` command: prefetch community and member repos
- add `gov4git cache update --seconds 120` command: prefetch community and member repos every 2 minutes
- add `cache_ttl_seconds` to `config.json`

Resolves https://github.com/gov4git/gov4git/issues/65