### PR TITLE
keep cron state in separate branch

### DIFF
--- a/github/deploy/deploy_on_gov4git_testing_project.sh
+++ b/github/deploy/deploy_on_gov4git_testing_project.sh
@@ -3,4 +3,4 @@
 gov4git -v github deploy \
      --token=$GITHUB_GOV4GIT_TESTING_TOKEN \
      --project=gov4git/testing.project \
-     --release=v1.1.10
+     --release=v1.1.11

--- a/github/directive.go
+++ b/github/directive.go
@@ -148,7 +148,7 @@ func processDirectiveIssue_StageOnly(
 	case d.IssueVotingCredits != nil:
 		err = must.Try(
 			func() {
-				balance.AddStageOnly(
+				balance.Add_StageOnly(
 					ctx,
 					govCloned.Public.Tree(),
 					member.User(d.IssueVotingCredits.To),
@@ -174,7 +174,7 @@ func processDirectiveIssue_StageOnly(
 	case d.TransferVotingCredits != nil:
 		err = must.Try(
 			func() {
-				balance.TransferStageOnly(
+				balance.Transfer_StageOnly(
 					ctx,
 					govCloned.Public.Tree(),
 					member.User(d.TransferVotingCredits.From),

--- a/github/issues.go
+++ b/github/issues.go
@@ -130,7 +130,7 @@ func ImportIssuesForPrioritization_StageOnly(
 	// load github issues and governance ballots, and
 	// index them under a common key space
 	ghOrderedIssues, ghIssues := LoadIssuesForPrioritization(ctx, repo, githubClient)
-	govBallots := filterIssuesForPrioritization(ballot.ListLocal(ctx, govCloned.Public.Tree()))
+	govBallots := filterIssuesForPrioritization(ballot.List_Local(ctx, govCloned.Public.Tree()))
 
 	// ensure every issue has a corresponding up-to-date ballot
 	for k, ghIssue := range ghIssues {
@@ -146,7 +146,7 @@ func ImportIssuesForPrioritization_StageOnly(
 				case ghIssue.Closed && !govBallot.Closed:
 					UpdateMeta_StageOnly(ctx, repo, govAddr, govCloned, ghIssue, govBallot)
 					UpdateFrozen_StageOnly(ctx, repo, govAddr, govCloned, ghIssue, govBallot)
-					ballot.CloseStageOnly(ctx, govAddr, govCloned, ghIssue.BallotName(), false)
+					ballot.Close_StageOnly(ctx, govAddr, govCloned, ghIssue.BallotName(), false)
 				case !ghIssue.Closed && govBallot.Closed:
 					UpdateMeta_StageOnly(ctx, repo, govAddr, govCloned, ghIssue, govBallot)
 					ballot.Reopen_StageOnly(ctx, govAddr, govCloned, ghIssue.BallotName())
@@ -157,7 +157,7 @@ func ImportIssuesForPrioritization_StageOnly(
 				}
 
 			} else { // no ballot for this issue, create it
-				ballot.OpenStageOnly(
+				ballot.Open_StageOnly(
 					ctx,
 					qv.QV{},
 					gov.GovAddress(govAddr.Public),
@@ -169,10 +169,10 @@ func ImportIssuesForPrioritization_StageOnly(
 					member.Everybody,
 				)
 				if ghIssue.Locked {
-					ballot.FreezeStageOnly(ctx, govAddr, govCloned, ghIssue.BallotName())
+					ballot.Freeze_StageOnly(ctx, govAddr, govCloned, ghIssue.BallotName())
 				}
 				if ghIssue.Closed {
-					ballot.CloseStageOnly(ctx, govAddr, govCloned, ghIssue.BallotName(), false)
+					ballot.Close_StageOnly(ctx, govAddr, govCloned, ghIssue.BallotName(), false)
 				}
 			}
 		} else { // issue is not for prioritization, freeze ballot if it exists and is open
@@ -181,7 +181,7 @@ func ImportIssuesForPrioritization_StageOnly(
 				// if ballot frozen, do nothing
 				// otherwise, freeze ballot
 				if !govBallot.Closed && !govBallot.Frozen {
-					ballot.FreezeStageOnly(ctx, govAddr, govCloned, ghIssue.BallotName())
+					ballot.Freeze_StageOnly(ctx, govAddr, govCloned, ghIssue.BallotName())
 				}
 			}
 		}
@@ -232,10 +232,10 @@ func UpdateFrozen_StageOnly(
 	case ghIssue.Locked && govBallot.Frozen:
 		return false
 	case ghIssue.Locked && !govBallot.Frozen:
-		ballot.FreezeStageOnly(ctx, govAddr, govCloned, ghIssue.BallotName())
+		ballot.Freeze_StageOnly(ctx, govAddr, govCloned, ghIssue.BallotName())
 		return true
 	case !ghIssue.Locked && govBallot.Frozen:
-		ballot.UnfreezeStageOnly(ctx, govAddr, govCloned, ghIssue.BallotName())
+		ballot.Unfreeze_StageOnly(ctx, govAddr, govCloned, ghIssue.BallotName())
 		return true
 	case !ghIssue.Locked && !govBallot.Frozen:
 		return false

--- a/github/join.go
+++ b/github/join.go
@@ -129,7 +129,7 @@ func processJoinRequestIssue_StageOnly(
 	// add user to community members
 	err = must.Try(
 		func() {
-			member.AddUserByPublicAddressStageOnly(ctx, govCloned.Public.Tree(), member.User(login), info.PublicAddress())
+			member.AddUserByPublicAddress_StageOnly(ctx, govCloned.Public.Tree(), member.User(login), info.PublicAddress())
 		},
 	)
 	if err != nil {

--- a/proto/balance/balance.go
+++ b/proto/balance/balance.go
@@ -17,19 +17,19 @@ func Set(ctx context.Context, addr gov.GovAddress, user member.User, key Balance
 	member.SetUserProp(ctx, addr, user, userPropKey(key), value)
 }
 
-func SetStageOnly(ctx context.Context, t *git.Tree, user member.User, key Balance, value float64) {
-	member.SetUserPropStageOnly(ctx, t, user, userPropKey(key), value)
+func Set_StageOnly(ctx context.Context, t *git.Tree, user member.User, key Balance, value float64) {
+	member.SetUserProp_StageOnly(ctx, t, user, userPropKey(key), value)
 }
 
 func Get(ctx context.Context, addr gov.GovAddress, user member.User, key Balance) float64 {
 	return member.GetUserPropOrDefault(ctx, addr, user, userPropKey(key), 0.0)
 }
 
-func GetLocal(ctx context.Context, t *git.Tree, user member.User, key Balance) float64 {
+func Get_Local(ctx context.Context, t *git.Tree, user member.User, key Balance) float64 {
 	return member.GetUserPropLocalOrDefault(ctx, t, user, userPropKey(key), 0.0)
 }
 
-func TryTransferStageOnly(
+func TryTransfer_StageOnly(
 	ctx context.Context,
 	t *git.Tree,
 	fromUser member.User,
@@ -38,10 +38,10 @@ func TryTransferStageOnly(
 	toBal Balance,
 	amount float64,
 ) error {
-	return must.Try(func() { TransferStageOnly(ctx, t, fromUser, fromBal, toUser, toBal, amount) })
+	return must.Try(func() { Transfer_StageOnly(ctx, t, fromUser, fromBal, toUser, toBal, amount) })
 }
 
-func TransferStageOnly(
+func Transfer_StageOnly(
 	ctx context.Context,
 	t *git.Tree,
 	fromUser member.User,
@@ -52,23 +52,23 @@ func TransferStageOnly(
 ) {
 	base.Infof("transfering %v units from %v:%v to %v:%v", amount, fromUser, fromBal, toUser, toBal)
 	must.Assertf(ctx, amount >= 0, "negative transfer")
-	prior := GetLocal(ctx, t, fromUser, fromBal)
+	prior := Get_Local(ctx, t, fromUser, fromBal)
 	must.Assertf(ctx, prior >= amount, "insufficient balance")
-	AddStageOnly(ctx, t, fromUser, fromBal, -amount)
-	AddStageOnly(ctx, t, toUser, toBal, amount)
+	Add_StageOnly(ctx, t, fromUser, fromBal, -amount)
+	Add_StageOnly(ctx, t, toUser, toBal, amount)
 }
 
-func TryChargeStageOnly(
+func TryCharge_StageOnly(
 	ctx context.Context,
 	t *git.Tree,
 	user member.User,
 	bal Balance,
 	amount float64,
 ) error {
-	return must.Try(func() { ChargeStageOnly(ctx, t, user, bal, amount) })
+	return must.Try(func() { Charge_StageOnly(ctx, t, user, bal, amount) })
 }
 
-func ChargeStageOnly(
+func Charge_StageOnly(
 	ctx context.Context,
 	t *git.Tree,
 	user member.User,
@@ -76,14 +76,14 @@ func ChargeStageOnly(
 	amount float64,
 ) {
 	base.Infof("charging %v units from %v:%v", amount, user, bal)
-	prior := GetLocal(ctx, t, user, bal)
+	prior := Get_Local(ctx, t, user, bal)
 	must.Assertf(ctx, prior >= amount, "insufficient balance")
-	AddStageOnly(ctx, t, user, bal, -amount)
+	Add_StageOnly(ctx, t, user, bal, -amount)
 }
 
 func Add(ctx context.Context, addr gov.GovAddress, user member.User, key Balance, value float64) float64 {
 	cloned := gov.Clone(ctx, addr)
-	prior := AddStageOnly(ctx, cloned.Tree(), user, key, value)
+	prior := Add_StageOnly(ctx, cloned.Tree(), user, key, value)
 	chg := git.NewChange[form.Map, float64](
 		fmt.Sprintf("Add %v to balance %v of user %v", value, key, user),
 		"balance_add",
@@ -96,15 +96,15 @@ func Add(ctx context.Context, addr gov.GovAddress, user member.User, key Balance
 	return prior
 }
 
-func AddStageOnly(ctx context.Context, t *git.Tree, user member.User, key Balance, value float64) float64 {
-	prior := GetLocal(ctx, t, user, key)
-	SetStageOnly(ctx, t, user, key, prior+value)
+func Add_StageOnly(ctx context.Context, t *git.Tree, user member.User, key Balance, value float64) float64 {
+	prior := Get_Local(ctx, t, user, key)
+	Set_StageOnly(ctx, t, user, key, prior+value)
 	return prior
 }
 
 func Mul(ctx context.Context, addr gov.GovAddress, user member.User, key Balance, value float64) float64 {
 	cloned := gov.Clone(ctx, addr)
-	prior := MulStageOnly(ctx, cloned.Tree(), user, key, value)
+	prior := Mul_StageOnly(ctx, cloned.Tree(), user, key, value)
 	chg := git.NewChange[form.Map, float64](
 		fmt.Sprintf("Multiply %v into balance %v of user %v", value, key, user),
 		"balance_mul",
@@ -117,8 +117,8 @@ func Mul(ctx context.Context, addr gov.GovAddress, user member.User, key Balance
 	return prior
 }
 
-func MulStageOnly(ctx context.Context, t *git.Tree, user member.User, key Balance, value float64) float64 {
-	prior := GetLocal(ctx, t, user, key)
-	SetStageOnly(ctx, t, user, key, prior*value)
+func Mul_StageOnly(ctx context.Context, t *git.Tree, user member.User, key Balance, value float64) float64 {
+	prior := Get_Local(ctx, t, user, key)
+	Set_StageOnly(ctx, t, user, key, prior*value)
 	return prior
 }

--- a/proto/ballot/ballot/all.go
+++ b/proto/ballot/ballot/all.go
@@ -25,7 +25,7 @@ func TallyAll(
 	base.Infof("fetching and tallying community votes ...")
 
 	govOwner := id.CloneOwner(ctx, id.OwnerAddress(govAddr))
-	chg := TallyAllStageOnly(ctx, govAddr, govOwner, maxPar)
+	chg := TallyAll_StageOnly(ctx, govAddr, govOwner, maxPar)
 	if len(chg.Result) == 0 {
 		return chg
 	}
@@ -34,7 +34,7 @@ func TallyAll(
 	return chg
 }
 
-func TallyAllStageOnly(
+func TallyAll_StageOnly(
 	ctx context.Context,
 	govAddr gov.OrganizerAddress,
 	govOwner id.OwnerCloned,
@@ -43,7 +43,7 @@ func TallyAllStageOnly(
 
 	// list all open ballots
 	communityTree := govOwner.Public.Tree()
-	ads := common.FilterOpenClosedAds(false, ListLocal(ctx, communityTree))
+	ads := common.FilterOpenClosedAds(false, List_Local(ctx, communityTree))
 
 	// compute union of all voter accounts from all open ballots
 	adVoters := make([]adVoters, len(ads))
@@ -52,9 +52,9 @@ func TallyAllStageOnly(
 		adVoters[i].Ad = ad
 		adVoters[i].VoterAccounts = map[member.User]member.Account{}
 		adVoters[i].VoterClones = map[member.User]git.Cloned{}
-		adVoters[i].Voters = member.ListGroupUsersLocal(ctx, communityTree, ad.Participants)
+		adVoters[i].Voters = member.ListGroupUsers_Local(ctx, communityTree, ad.Participants)
 		for _, user := range adVoters[i].Voters {
-			account := member.GetUserLocal(ctx, communityTree, user)
+			account := member.GetUser_Local(ctx, communityTree, user)
 			adVoters[i].VoterAccounts[user] = account
 			allVoters[user] = account
 		}
@@ -74,7 +74,7 @@ func TallyAllStageOnly(
 	tallyChanges := []git.Change[map[string]form.Form, common.Tally]{}
 	tallies := []common.Tally{}
 	for _, adv := range adVoters {
-		if tallyChg, changed := tallyVotersClonedStageOnly(ctx, govAddr, govOwner, adv.Ad.Name, adv.VoterAccounts, adv.VoterClones); changed {
+		if tallyChg, changed := tallyVotersCloned_StageOnly(ctx, govAddr, govOwner, adv.Ad.Name, adv.VoterAccounts, adv.VoterClones); changed {
 			tallyChanges = append(tallyChanges, tallyChg)
 			tallies = append(tallies, tallyChg.Result)
 		}

--- a/proto/ballot/ballot/close.go
+++ b/proto/ballot/ballot/close.go
@@ -22,13 +22,13 @@ func Close(
 ) git.Change[form.Map, common.Outcome] {
 
 	govCloned := id.CloneOwner(ctx, id.OwnerAddress(govAddr))
-	chg := CloseStageOnly(ctx, govAddr, govCloned, ballotName, cancel)
+	chg := Close_StageOnly(ctx, govAddr, govCloned, ballotName, cancel)
 	proto.Commit(ctx, govCloned.Public.Tree(), chg)
 	govCloned.Public.Push(ctx)
 	return chg
 }
 
-func CloseStageOnly(
+func Close_StageOnly(
 	ctx context.Context,
 	govAddr gov.OrganizerAddress,
 	govCloned id.OwnerCloned,

--- a/proto/ballot/ballot/freeze.go
+++ b/proto/ballot/ballot/freeze.go
@@ -21,13 +21,13 @@ func Freeze(
 ) git.ChangeNoResult {
 
 	govCloned := id.CloneOwner(ctx, id.OwnerAddress(govAddr))
-	chg := FreezeStageOnly(ctx, govAddr, govCloned, ballotName)
+	chg := Freeze_StageOnly(ctx, govAddr, govCloned, ballotName)
 	proto.Commit(ctx, govCloned.Public.Tree(), chg)
 	govCloned.Public.Push(ctx)
 	return chg
 }
 
-func FreezeStageOnly(
+func Freeze_StageOnly(
 	ctx context.Context,
 	govAddr gov.OrganizerAddress,
 	govCloned id.OwnerCloned,

--- a/proto/ballot/ballot/list.go
+++ b/proto/ballot/ballot/list.go
@@ -17,10 +17,10 @@ func List(
 	govAddr gov.GovAddress,
 ) []common.Advertisement {
 
-	return ListLocal(ctx, git.CloneOne(ctx, git.Address(govAddr)).Tree())
+	return List_Local(ctx, git.CloneOne(ctx, git.Address(govAddr)).Tree())
 }
 
-func ListLocal(
+func List_Local(
 	ctx context.Context,
 	govTree *git.Tree,
 ) []common.Advertisement {
@@ -55,10 +55,10 @@ func ListFilter(
 	withParticipant member.User,
 ) []common.Advertisement {
 
-	return ListFilterLocal(ctx, git.CloneOne(ctx, git.Address(govAddr)).Tree(), onlyOpen, onlyClosed, onlyFrozen, withParticipant)
+	return ListFilter_Local(ctx, git.CloneOne(ctx, git.Address(govAddr)).Tree(), onlyOpen, onlyClosed, onlyFrozen, withParticipant)
 }
 
-func ListFilterLocal(
+func ListFilter_Local(
 	ctx context.Context,
 	govTree *git.Tree,
 	onlyOpen bool,
@@ -67,7 +67,7 @@ func ListFilterLocal(
 	withParticipant member.User,
 ) []common.Advertisement {
 
-	ads := ListLocal(ctx, govTree)
+	ads := List_Local(ctx, govTree)
 	if onlyOpen {
 		ads = common.FilterOpenClosedAds(false, ads)
 	}
@@ -78,7 +78,7 @@ func ListFilterLocal(
 		ads = common.FilterFrozenAds(true, ads)
 	}
 	if withParticipant != "" {
-		userGroups := member.ListUserGroupsLocal(ctx, govTree, withParticipant)
+		userGroups := member.ListUserGroups_Local(ctx, govTree, withParticipant)
 		ads = common.FilterWithParticipants(userGroups, ads)
 	}
 	return ads

--- a/proto/ballot/ballot/open.go
+++ b/proto/ballot/ballot/open.go
@@ -26,13 +26,13 @@ func Open(
 ) git.Change[form.Map, common.BallotAddress] {
 
 	govCloned := git.CloneOne(ctx, git.Address(govAddr))
-	chg := OpenStageOnly(ctx, strat, govAddr, govCloned, name, title, description, choices, participants)
+	chg := Open_StageOnly(ctx, strat, govAddr, govCloned, name, title, description, choices, participants)
 	proto.Commit(ctx, govCloned.Tree(), chg)
 	govCloned.Push(ctx)
 	return chg
 }
 
-func OpenStageOnly(
+func Open_StageOnly(
 	ctx context.Context,
 	strat common.Strategy,
 	govAddr gov.GovAddress,
@@ -51,7 +51,7 @@ func OpenStageOnly(
 	}
 
 	// verify group exists
-	if !member.IsGroupLocal(ctx, govCloned.Tree(), participants) {
+	if !member.IsGroup_Local(ctx, govCloned.Tree(), participants) {
 		must.Errorf(ctx, "participant group %v does not exist", participants)
 	}
 

--- a/proto/ballot/ballot/show.go
+++ b/proto/ballot/ballot/show.go
@@ -13,10 +13,10 @@ import (
 
 func Show(ctx context.Context, govAddr gov.GovAddress, ballotName ns.NS) common.AdStrategyTally {
 
-	return ShowLocal(ctx, govAddr, git.CloneOne(ctx, git.Address(govAddr)).Tree(), ballotName)
+	return Show_Local(ctx, govAddr, git.CloneOne(ctx, git.Address(govAddr)).Tree(), ballotName)
 }
 
-func ShowLocal(
+func Show_Local(
 	ctx context.Context,
 	govAddr gov.GovAddress,
 	govTree *git.Tree,

--- a/proto/ballot/ballot/tally.go
+++ b/proto/ballot/ballot/tally.go
@@ -24,7 +24,7 @@ func Tally(
 ) git.Change[form.Map, common.Tally] {
 
 	govOwner := id.CloneOwner(ctx, id.OwnerAddress(govAddr))
-	chg, changed := TallyStageOnly(ctx, govAddr, govOwner, ballotName)
+	chg, changed := Tally_StageOnly(ctx, govAddr, govOwner, ballotName)
 	if !changed {
 		return chg
 	}
@@ -33,7 +33,7 @@ func Tally(
 	return chg
 }
 
-func TallyStageOnly(
+func Tally_StageOnly(
 	ctx context.Context,
 	govAddr gov.OrganizerAddress,
 	govOwner id.OwnerCloned,
@@ -45,8 +45,8 @@ func TallyStageOnly(
 
 	// compute all participating voter accounts
 	voterAccounts := map[member.User]member.Account{}
-	for _, user := range member.ListGroupUsersLocal(ctx, communityTree, ad.Participants) {
-		voterAccounts[user] = member.GetUserLocal(ctx, communityTree, user)
+	for _, user := range member.ListGroupUsers_Local(ctx, communityTree, ad.Participants) {
+		voterAccounts[user] = member.GetUser_Local(ctx, communityTree, user)
 	}
 
 	// fetch repos of all participating voters
@@ -55,10 +55,10 @@ func TallyStageOnly(
 		votersCloned[u] = git.CloneOne(ctx, git.Address(a.PublicAddress))
 	}
 
-	return tallyVotersClonedStageOnly(ctx, govAddr, govOwner, ballotName, voterAccounts, votersCloned)
+	return tallyVotersCloned_StageOnly(ctx, govAddr, govOwner, ballotName, voterAccounts, votersCloned)
 }
 
-func tallyVotersClonedStageOnly(
+func tallyVotersCloned_StageOnly(
 	ctx context.Context,
 	govAddr gov.OrganizerAddress,
 	govOwner id.OwnerCloned,

--- a/proto/ballot/ballot/track.go
+++ b/proto/ballot/ballot/track.go
@@ -21,10 +21,10 @@ func Track(
 
 	govCloned := git.CloneOne(ctx, git.Address(govAddr))
 	voterOwner := id.CloneOwner(ctx, voterAddr)
-	return TrackStageOnly(ctx, voterAddr, govAddr, voterOwner, govCloned, ballotName)
+	return Track_StageOnly(ctx, voterAddr, govAddr, voterOwner, govCloned, ballotName)
 }
 
-func TrackStageOnly(
+func Track_StageOnly(
 	ctx context.Context,
 	voterAddr id.OwnerAddress,
 	govAddr gov.GovAddress,
@@ -35,7 +35,7 @@ func TrackStageOnly(
 
 	// determine the voter's username in the community
 	voterCred := id.GetPublicCredentials(ctx, voterOwner.Public.Tree())
-	users := member.LookupUserByIDLocal(ctx, govCloned.Tree(), voterCred.ID)
+	users := member.LookupUserByID_Local(ctx, govCloned.Tree(), voterCred.ID)
 	must.Assertf(ctx, len(users) > 0, "user not found in community")
 	user := users[0]
 

--- a/proto/ballot/ballot/unfreeze.go
+++ b/proto/ballot/ballot/unfreeze.go
@@ -21,13 +21,13 @@ func Unfreeze(
 ) git.ChangeNoResult {
 
 	govCloned := id.CloneOwner(ctx, id.OwnerAddress(govAddr))
-	chg := UnfreezeStageOnly(ctx, govAddr, govCloned, ballotName)
+	chg := Unfreeze_StageOnly(ctx, govAddr, govCloned, ballotName)
 	proto.Commit(ctx, govCloned.Public.Tree(), chg)
 	govCloned.Public.Push(ctx)
 	return chg
 }
 
-func UnfreezeStageOnly(
+func Unfreeze_StageOnly(
 	ctx context.Context,
 	govAddr gov.OrganizerAddress,
 	govCloned id.OwnerCloned,

--- a/proto/ballot/ballot/vote.go
+++ b/proto/ballot/ballot/vote.go
@@ -25,14 +25,14 @@ func Vote(
 
 	govCloned := git.CloneOne(ctx, git.Address(govAddr))
 	voterOwner := id.CloneOwner(ctx, voterAddr)
-	chg := VoteStageOnly(ctx, voterAddr, govAddr, voterOwner, govCloned, ballotName, elections)
+	chg := Vote_StageOnly(ctx, voterAddr, govAddr, voterOwner, govCloned, ballotName, elections)
 	proto.Commit(ctx, voterOwner.Public.Tree(), chg)
 	voterOwner.Public.Push(ctx)
 
 	return chg
 }
 
-func VoteStageOnly(
+func Vote_StageOnly(
 	ctx context.Context,
 	voterAddr id.OwnerAddress,
 	govAddr gov.GovAddress,

--- a/proto/ballot/qv/cancel.go
+++ b/proto/ballot/qv/cancel.go
@@ -20,7 +20,7 @@ func (qv QV) Cancel(
 
 	// refund users
 	for user, spent := range tally.Charges {
-		balance.AddStageOnly(ctx, govOwner.Public.Tree(), user, VotingCredits, spent)
+		balance.Add_StageOnly(ctx, govOwner.Public.Tree(), user, VotingCredits, spent)
 	}
 
 	return git.NewChange(

--- a/proto/ballot/qv/tally.go
+++ b/proto/ballot/qv/tally.go
@@ -91,5 +91,5 @@ func (qv QV) tally(
 }
 
 func chargeUser(ctx context.Context, govCloned git.Cloned, user member.User, charge float64) error {
-	return balance.TryChargeStageOnly(ctx, govCloned.Tree(), user, VotingCredits, charge)
+	return balance.TryCharge_StageOnly(ctx, govCloned.Tree(), user, VotingCredits, charge)
 }

--- a/proto/ballot/qv/verify.go
+++ b/proto/ballot/qv/verify.go
@@ -23,7 +23,7 @@ func (qv QV) VerifyElections(
 ) {
 
 	voterCred := id.GetPublicCredentials(ctx, voterCloned.Public.Tree())
-	user := member.LookupUserByIDLocal(ctx, govCloned.Tree(), voterCred.ID)
+	user := member.LookupUserByID_Local(ctx, govCloned.Tree(), voterCred.ID)
 	if len(user) == 0 {
 		must.Errorf(ctx, "cannot find user with id %v in the community", voterCred.ID)
 	}

--- a/proto/boot/boot.go
+++ b/proto/boot/boot.go
@@ -16,20 +16,20 @@ func Boot(
 ) git.Change[form.None, id.PrivateCredentials] {
 
 	ownerCloned := id.CloneOwner(ctx, ownerAddr)
-	privChg := BootLocal(ctx, ownerAddr, ownerCloned)
+	privChg := Boot_Local(ctx, ownerAddr, ownerCloned)
 	ownerCloned.Public.Push(ctx)
 	ownerCloned.Private.Push(ctx)
 	return privChg
 }
 
-func BootLocal(
+func Boot_Local(
 	ctx context.Context,
 	ownerAddr id.OwnerAddress,
 	ownerCloned id.OwnerCloned,
 ) git.Change[form.None, id.PrivateCredentials] {
 
-	chg := id.InitLocal(ctx, ownerAddr, ownerCloned)
-	chg2 := member.SetGroupStageOnly(ctx, ownerCloned.Public.Tree(), member.Everybody)
+	chg := id.Init_Local(ctx, ownerAddr, ownerCloned)
+	chg2 := member.SetGroup_StageOnly(ctx, ownerCloned.Public.Tree(), member.Everybody)
 	proto.Commit(ctx, ownerCloned.Public.Tree(), chg2)
 
 	return chg

--- a/proto/bureau/process.go
+++ b/proto/bureau/process.go
@@ -25,7 +25,7 @@ func Process(
 	base.Infof("fetching service requests from the community ...")
 
 	govOwner := id.CloneOwner(ctx, id.OwnerAddress(govAddr))
-	chg, changed := ProcessStageOnly(ctx, govAddr, govOwner, group)
+	chg, changed := Process_StageOnly(ctx, govAddr, govOwner, group)
 	if changed {
 		proto.Commit(ctx, govOwner.Public.Tree(), chg)
 		govOwner.Public.Push(ctx)
@@ -33,7 +33,7 @@ func Process(
 	return chg
 }
 
-func ProcessStageOnly(
+func Process_StageOnly(
 	ctx context.Context,
 	govAddr gov.OrganizerAddress,
 	govOwner id.OwnerCloned,
@@ -43,12 +43,12 @@ func ProcessStageOnly(
 	communityTree := govOwner.Public.Tree()
 
 	// list participating users
-	users := member.ListGroupUsersLocal(ctx, communityTree, group)
+	users := member.ListGroupUsers_Local(ctx, communityTree, group)
 
 	// get user accounts
 	accounts := make([]member.Account, len(users))
 	for i, user := range users {
-		accounts[i] = member.GetUserLocal(ctx, communityTree, user)
+		accounts[i] = member.GetUser_Local(ctx, communityTree, user)
 	}
 
 	// fetch user requests
@@ -60,7 +60,7 @@ func ProcessStageOnly(
 
 	// process requests
 	for _, fetched := range fetchedReqs {
-		nOK, nErr := processRequestStageOnly(ctx, govAddr, govOwner, fetched)
+		nOK, nErr := processRequest_StageOnly(ctx, govAddr, govOwner, fetched)
 		if nOK+nErr > 0 {
 			changed = true
 		}
@@ -72,7 +72,7 @@ func ProcessStageOnly(
 	), changed
 }
 
-func processRequestStageOnly(
+func processRequest_StageOnly(
 	ctx context.Context,
 	govAddr gov.OrganizerAddress,
 	govOwner id.OwnerCloned,
@@ -89,7 +89,7 @@ func processRequestStageOnly(
 			continue
 		}
 		err := must.Try(func() {
-			balance.TransferStageOnly(
+			balance.Transfer_StageOnly(
 				ctx,
 				govOwner.Public.Tree(),
 				req.Transfer.FromUser, req.Transfer.FromBalance,

--- a/proto/bureau/transfer.go
+++ b/proto/bureau/transfer.go
@@ -28,13 +28,13 @@ func Transfer(
 	govCloned := git.CloneOne(ctx, git.Address(govAddr))
 	// userRepo, userTree := id.CloneOwner(ctx, userAddr)
 	userOwner := id.CloneOwner(ctx, userAddr)
-	chg := TransferStageOnly(ctx, userAddr, govAddr, userOwner, govCloned, fromUserOpt, fromBalance, toUser, toBalance, amount)
+	chg := Transfer_StageOnly(ctx, userAddr, govAddr, userOwner, govCloned, fromUserOpt, fromBalance, toUser, toBalance, amount)
 	proto.Commit(ctx, userOwner.Public.Tree(), chg)
 	userOwner.Public.Push(ctx)
 	return chg
 }
 
-func TransferStageOnly(
+func Transfer_StageOnly(
 	ctx context.Context,
 	userAddr id.OwnerAddress,
 	govAddr gov.GovAddress,
@@ -51,7 +51,7 @@ func TransferStageOnly(
 
 	// find the user name of userAddr in the community repo
 	if fromUserOpt == "" {
-		us := member.LookupUserByIDLocal(ctx, govCloned.Tree(), userCred.ID)
+		us := member.LookupUserByID_Local(ctx, govCloned.Tree(), userCred.ID)
 		switch len(us) {
 		case 0:
 			must.Errorf(ctx, "%s not found in community %v", userAddr.Public, govAddr)

--- a/proto/cron/cron.go
+++ b/proto/cron/cron.go
@@ -34,10 +34,16 @@ func Cron(
 ) form.Map {
 
 	govCloned := id.CloneOwner(ctx, id.OwnerAddress(govAddr))
-	t := govCloned.Public.Tree()
+	govTree := govCloned.Public.Tree()
+
+	// use a separate branch for cron logs
+	cronAddr := git.Address(govAddr.Public)
+	cronAddr.Branch = cronAddr.Branch + "-cron"
+	cronCloned := git.CloneOne(ctx, cronAddr)
+	cronTree := cronCloned.Tree()
 
 	// read cron state
-	state, err := git.TryFromFile[CronState](ctx, t, CronNS.Path())
+	state, err := git.TryFromFile[CronState](ctx, cronTree, CronNS.Path())
 	must.Assertf(ctx, err == nil || err == os.ErrNotExist, "opening cron state (%v)", err)
 
 	now := time.Now()
@@ -74,9 +80,7 @@ func Cron(
 		state.LastCommunityTally = time.Now()
 	}
 
-	// write cron state
 	report["cron"] = state
-	git.ToFileStage(ctx, t, CronNS.Path(), state)
 	cronChg := git.NewChange[form.Map, form.Map](
 		fmt.Sprintf("Cron job."),
 		"cron",
@@ -85,9 +89,18 @@ func Cron(
 		nil,
 	)
 
-	// commit and push
-	proto.Commit(ctx, govCloned.Public.Tree(), cronChg)
-	govCloned.Public.Push(ctx)
+	// push gov state
+	govStatus, err := govTree.Status()
+	must.NoError(ctx, err)
+	if !govStatus.IsClean() {
+		proto.Commit(ctx, govCloned.Public.Tree(), cronChg)
+		govCloned.Public.Push(ctx)
+	}
+
+	// push cron state
+	git.ToFileStage(ctx, cronTree, CronNS.Path(), state)
+	proto.Commit(ctx, cronTree, cronChg)
+	cronCloned.Push(ctx)
 
 	return report
 }

--- a/proto/cron/cron.go
+++ b/proto/cron/cron.go
@@ -75,7 +75,7 @@ func Cron(
 	if shouldSyncCommunity {
 
 		// tally votes for all ballots from all community members
-		report["tally"] = ballot.TallyAllStageOnly(ctx, govAddr, govCloned, maxPar).Result
+		report["tally"] = ballot.TallyAll_StageOnly(ctx, govAddr, govCloned, maxPar).Result
 
 		state.LastCommunityTally = time.Now()
 	}

--- a/proto/cron/cron.go
+++ b/proto/cron/cron.go
@@ -38,7 +38,7 @@ func Cron(
 
 	// use a separate branch for cron logs
 	cronAddr := git.Address(govAddr.Public)
-	cronAddr.Branch = cronAddr.Branch + "-cron"
+	cronAddr.Branch = cronAddr.Branch + "/cron"
 	cronCloned := git.CloneOne(ctx, cronAddr)
 	cronTree := cronCloned.Tree()
 

--- a/proto/id/init.go
+++ b/proto/id/init.go
@@ -14,27 +14,27 @@ func Init(
 	ownerAddr OwnerAddress,
 ) git.Change[form.None, PrivateCredentials] {
 	ownerCloned := CloneOwner(ctx, ownerAddr)
-	privChg := InitLocal(ctx, ownerAddr, ownerCloned)
+	privChg := Init_Local(ctx, ownerAddr, ownerCloned)
 
 	ownerCloned.Public.Push(ctx)
 	ownerCloned.Private.Push(ctx)
 	return privChg
 }
 
-func InitLocal(
+func Init_Local(
 	ctx context.Context,
 	ownerAddr OwnerAddress,
 	ownerCloned OwnerCloned,
 ) git.Change[form.None, PrivateCredentials] {
 
-	privChg := initPrivateStageOnly(ctx, ownerCloned.Private.Tree(), ownerAddr)
-	pubChg := initPublicStageOnly(ctx, ownerCloned.Public.Tree(), privChg.Result.PublicCredentials)
+	privChg := initPrivate_StageOnly(ctx, ownerCloned.Private.Tree(), ownerAddr)
+	pubChg := initPublic_StageOnly(ctx, ownerCloned.Public.Tree(), privChg.Result.PublicCredentials)
 	proto.Commit(ctx, ownerCloned.Private.Tree(), privChg)
 	proto.Commit(ctx, ownerCloned.Public.Tree(), pubChg)
 	return privChg
 }
 
-func initPrivateStageOnly(ctx context.Context, priv *git.Tree, ownerAddr OwnerAddress) git.Change[form.None, PrivateCredentials] {
+func initPrivate_StageOnly(ctx context.Context, priv *git.Tree, ownerAddr OwnerAddress) git.Change[form.None, PrivateCredentials] {
 	if _, err := priv.Filesystem.Stat(PrivateCredentialsNS.Path()); err == nil {
 		must.Errorf(ctx, "private credentials file already exists")
 	}
@@ -50,7 +50,7 @@ func initPrivateStageOnly(ctx context.Context, priv *git.Tree, ownerAddr OwnerAd
 	)
 }
 
-func initPublicStageOnly(ctx context.Context, pub *git.Tree, cred PublicCredentials) git.ChangeNoResult {
+func initPublic_StageOnly(ctx context.Context, pub *git.Tree, cred PublicCredentials) git.ChangeNoResult {
 	if _, err := pub.Filesystem.Stat(PublicCredentialsNS.Path()); err == nil {
 		must.Errorf(ctx, "public credentials file already exists")
 	}

--- a/proto/mail/confirm_test.go
+++ b/proto/mail/confirm_test.go
@@ -16,8 +16,8 @@ func TestConfirm(t *testing.T) {
 	ctx := testutil.NewCtx(t, runtime.TestWithCache)
 	testSenderID := id.NewTestID(ctx, t, git.MainBranch, false)
 	testReceiverID := id.NewTestID(ctx, t, git.MainBranch, false)
-	id.InitLocal(ctx, testSenderID.OwnerAddress(), testSenderID.OwnerCloned())
-	id.InitLocal(ctx, testReceiverID.OwnerAddress(), testReceiverID.OwnerCloned())
+	id.Init_Local(ctx, testSenderID.OwnerAddress(), testSenderID.OwnerCloned())
+	id.Init_Local(ctx, testReceiverID.OwnerAddress(), testReceiverID.OwnerCloned())
 
 	const testTopic = "topic"
 	var testMsg []string = []string{"a", "b", "c"}
@@ -53,8 +53,8 @@ func TestConfirmSigned(t *testing.T) {
 	ctx := testutil.NewCtx(t, runtime.TestWithCache)
 	testSenderID := id.NewTestID(ctx, t, git.MainBranch, false)
 	testReceiverID := id.NewTestID(ctx, t, git.MainBranch, false)
-	id.InitLocal(ctx, testSenderID.OwnerAddress(), testSenderID.OwnerCloned())
-	id.InitLocal(ctx, testReceiverID.OwnerAddress(), testReceiverID.OwnerCloned())
+	id.Init_Local(ctx, testSenderID.OwnerAddress(), testSenderID.OwnerCloned())
+	id.Init_Local(ctx, testReceiverID.OwnerAddress(), testReceiverID.OwnerCloned())
 
 	const testTopic = "topic"
 	var testMsg []string = []string{"a", "b", "c"}
@@ -90,8 +90,8 @@ func TestConfirmCall(t *testing.T) {
 	ctx := testutil.NewCtx(t, runtime.TestWithCache)
 	testSenderID := id.NewTestID(ctx, t, git.MainBranch, false)
 	testReceiverID := id.NewTestID(ctx, t, git.MainBranch, false)
-	id.InitLocal(ctx, testSenderID.OwnerAddress(), testSenderID.OwnerCloned())
-	id.InitLocal(ctx, testReceiverID.OwnerAddress(), testReceiverID.OwnerCloned())
+	id.Init_Local(ctx, testSenderID.OwnerAddress(), testSenderID.OwnerCloned())
+	id.Init_Local(ctx, testReceiverID.OwnerAddress(), testReceiverID.OwnerCloned())
 
 	const testTopic = "topic"
 	var testMsg []string = []string{"a", "b", "c"}

--- a/proto/mail/reqresp_test.go
+++ b/proto/mail/reqresp_test.go
@@ -14,8 +14,8 @@ func TestReqResp(t *testing.T) {
 	ctx := testutil.NewCtx(t, runtime.TestWithCache)
 	testSenderID := id.NewTestID(ctx, t, git.MainBranch, false)
 	testReceiverID := id.NewTestID(ctx, t, git.MainBranch, false)
-	id.InitLocal(ctx, testSenderID.OwnerAddress(), testSenderID.OwnerCloned())
-	id.InitLocal(ctx, testReceiverID.OwnerAddress(), testReceiverID.OwnerCloned())
+	id.Init_Local(ctx, testSenderID.OwnerAddress(), testSenderID.OwnerCloned())
+	id.Init_Local(ctx, testReceiverID.OwnerAddress(), testReceiverID.OwnerCloned())
 
 	const testTopic = "topic"
 	var testMsg []string = []string{"a", "b", "c"}

--- a/proto/mail/sendreceive_test.go
+++ b/proto/mail/sendreceive_test.go
@@ -14,8 +14,8 @@ func TestSendReceive(t *testing.T) {
 	ctx := testutil.NewCtx(t, runtime.TestWithCache)
 	testSenderID := id.NewTestID(ctx, t, git.MainBranch, false)
 	testReceiverID := id.NewTestID(ctx, t, git.MainBranch, false)
-	id.InitLocal(ctx, testSenderID.OwnerAddress(), testSenderID.OwnerCloned())
-	id.InitLocal(ctx, testReceiverID.OwnerAddress(), testReceiverID.OwnerCloned())
+	id.Init_Local(ctx, testSenderID.OwnerAddress(), testSenderID.OwnerCloned())
+	id.Init_Local(ctx, testReceiverID.OwnerAddress(), testReceiverID.OwnerCloned())
 
 	const testTopic = "topic"
 	var testMsg []string = []string{"a", "b", "c"}
@@ -77,8 +77,8 @@ func TestSendReceiveSigned(t *testing.T) {
 	ctx := testutil.NewCtx(t, runtime.TestWithCache)
 	testSenderID := id.NewTestID(ctx, t, git.MainBranch, false)
 	testReceiverID := id.NewTestID(ctx, t, git.MainBranch, false)
-	id.InitLocal(ctx, testSenderID.OwnerAddress(), testSenderID.OwnerCloned())
-	id.InitLocal(ctx, testReceiverID.OwnerAddress(), testReceiverID.OwnerCloned())
+	id.Init_Local(ctx, testSenderID.OwnerAddress(), testSenderID.OwnerCloned())
+	id.Init_Local(ctx, testReceiverID.OwnerAddress(), testReceiverID.OwnerCloned())
 
 	const testTopic = "topic"
 	var testMsg []string = []string{"a", "b", "c"}

--- a/proto/member/group.go
+++ b/proto/member/group.go
@@ -13,20 +13,20 @@ import (
 
 func SetGroup(ctx context.Context, addr gov.GovAddress, name Group) {
 	cloned := gov.Clone(ctx, addr)
-	chg := SetGroupStageOnly(ctx, cloned.Tree(), name)
+	chg := SetGroup_StageOnly(ctx, cloned.Tree(), name)
 	proto.Commit(ctx, cloned.Tree(), chg)
 	cloned.Push(ctx)
 }
 
-func SetGroupStageOnly(ctx context.Context, t *git.Tree, name Group) git.ChangeNoResult {
+func SetGroup_StageOnly(ctx context.Context, t *git.Tree, name Group) git.ChangeNoResult {
 	return groupsKV.Set(ctx, groupsNS, t, name, form.None{})
 }
 
 func IsGroup(ctx context.Context, addr gov.GovAddress, name Group) bool {
-	return IsGroupLocal(ctx, gov.Clone(ctx, addr).Tree(), name)
+	return IsGroup_Local(ctx, gov.Clone(ctx, addr).Tree(), name)
 }
 
-func IsGroupLocal(ctx context.Context, t *git.Tree, name Group) bool {
+func IsGroup_Local(ctx context.Context, t *git.Tree, name Group) bool {
 	err := must.Try(func() { groupsKV.Get(ctx, groupsNS, t, name) })
 	return err == nil
 }
@@ -39,20 +39,20 @@ func AddGroup(ctx context.Context, addr gov.GovAddress, name Group) {
 }
 
 func AddGroupStageOnly(ctx context.Context, t *git.Tree, name Group) git.ChangeNoResult {
-	if IsGroupLocal(ctx, t, name) {
+	if IsGroup_Local(ctx, t, name) {
 		must.Panic(ctx, fmt.Errorf("group already exists"))
 	}
-	return SetGroupStageOnly(ctx, t, name)
+	return SetGroup_StageOnly(ctx, t, name)
 }
 
 func RemoveGroup(ctx context.Context, addr gov.GovAddress, name Group) {
 	cloned := gov.Clone(ctx, addr)
-	chg := RemoveGroupStageOnly(ctx, cloned.Tree(), name)
+	chg := RemoveGroup_StageOnly(ctx, cloned.Tree(), name)
 	proto.Commit(ctx, cloned.Tree(), chg)
 	cloned.Push(ctx)
 }
 
-func RemoveGroupStageOnly(ctx context.Context, t *git.Tree, name Group) git.ChangeNoResult {
+func RemoveGroup_StageOnly(ctx context.Context, t *git.Tree, name Group) git.ChangeNoResult {
 	groupsKV.Remove(ctx, groupsNS, t, name)
 	groupUsersKKV.RemovePrimary(ctx, groupUsersNS, t, name) // remove memberships
 	return git.NewChangeNoResult(fmt.Sprintf("Remove group %v", name), "member_remove_group")

--- a/proto/member/member.go
+++ b/proto/member/member.go
@@ -20,22 +20,22 @@ type Group string
 
 func AddMember(ctx context.Context, addr gov.GovAddress, user User, group Group) {
 	cloned := gov.Clone(ctx, addr)
-	chg := AddMemberStageOnly(ctx, cloned.Tree(), user, group)
+	chg := AddMember_StageOnly(ctx, cloned.Tree(), user, group)
 	proto.Commit(ctx, cloned.Tree(), chg)
 	cloned.Push(ctx)
 }
 
-func AddMemberStageOnly(ctx context.Context, t *git.Tree, user User, group Group) git.ChangeNoResult {
+func AddMember_StageOnly(ctx context.Context, t *git.Tree, user User, group Group) git.ChangeNoResult {
 	userGroupsKKV.Set(ctx, userGroupsNS, t, user, group, true)
 	groupUsersKKV.Set(ctx, groupUsersNS, t, group, user, true)
 	return git.NewChangeNoResult(fmt.Sprintf("Added user %v to group %v", user, group), "member_add_member")
 }
 
 func IsMember(ctx context.Context, addr gov.GovAddress, user User, group Group) bool {
-	return IsMemberLocal(ctx, gov.Clone(ctx, addr).Tree(), user, group)
+	return IsMember_Local(ctx, gov.Clone(ctx, addr).Tree(), user, group)
 }
 
-func IsMemberLocal(ctx context.Context, t *git.Tree, user User, group Group) bool {
+func IsMember_Local(ctx context.Context, t *git.Tree, user User, group Group) bool {
 	var userHasGroup, groupHasUser bool
 	must.Try(
 		func() { userHasGroup = userGroupsKKV.Get(ctx, userGroupsNS, t, user, group) },
@@ -48,29 +48,29 @@ func IsMemberLocal(ctx context.Context, t *git.Tree, user User, group Group) boo
 
 func RemoveMember(ctx context.Context, addr gov.GovAddress, user User, group Group) {
 	cloned := gov.Clone(ctx, addr)
-	chg := RemoveMemberStageOnly(ctx, cloned.Tree(), user, group)
+	chg := RemoveMember_StageOnly(ctx, cloned.Tree(), user, group)
 	proto.Commit(ctx, cloned.Tree(), chg)
 	cloned.Push(ctx)
 }
 
-func RemoveMemberStageOnly(ctx context.Context, t *git.Tree, user User, group Group) git.ChangeNoResult {
+func RemoveMember_StageOnly(ctx context.Context, t *git.Tree, user User, group Group) git.ChangeNoResult {
 	userGroupsKKV.Remove(ctx, userGroupsNS, t, user, group)
 	groupUsersKKV.Remove(ctx, groupUsersNS, t, group, user)
 	return git.NewChangeNoResult(fmt.Sprintf("Removed user %v from group %v", user, group), "member_remove_member")
 }
 
 func ListUserGroups(ctx context.Context, addr gov.GovAddress, user User) []Group {
-	return ListUserGroupsLocal(ctx, gov.Clone(ctx, addr).Tree(), user)
+	return ListUserGroups_Local(ctx, gov.Clone(ctx, addr).Tree(), user)
 }
 
-func ListUserGroupsLocal(ctx context.Context, t *git.Tree, user User) []Group {
+func ListUserGroups_Local(ctx context.Context, t *git.Tree, user User) []Group {
 	return userGroupsKKV.ListSecondaryKeys(ctx, userGroupsNS, t, user)
 }
 
 func ListGroupUsers(ctx context.Context, addr gov.GovAddress, group Group) []User {
-	return ListGroupUsersLocal(ctx, gov.Clone(ctx, addr).Tree(), group)
+	return ListGroupUsers_Local(ctx, gov.Clone(ctx, addr).Tree(), group)
 }
 
-func ListGroupUsersLocal(ctx context.Context, t *git.Tree, group Group) []User {
+func ListGroupUsers_Local(ctx context.Context, t *git.Tree, group Group) []User {
 	return groupUsersKKV.ListSecondaryKeys(ctx, groupUsersNS, t, group)
 }

--- a/proto/member/member_test.go
+++ b/proto/member/member_test.go
@@ -24,35 +24,35 @@ func TestMember(t *testing.T) {
 			Branch: git.MainBranch,
 		},
 	}
-	AddUserStageOnly(ctx, wt, u1, r1)
-	r1Got := GetUserLocal(ctx, wt, u1)
+	AddUser_StageOnly(ctx, wt, u1, r1)
+	r1Got := GetUser_Local(ctx, wt, u1)
 	if r1 != r1Got {
 		t.Fatalf("expecting %v, got %v", r1, r1Got)
 	}
 
-	if !IsMemberLocal(ctx, wt, u1, Everybody) {
+	if !IsMember_Local(ctx, wt, u1, Everybody) {
 		t.Fatalf("expecting is member")
 	}
 
-	allUsers := ListGroupUsersLocal(ctx, wt, Everybody)
+	allUsers := ListGroupUsers_Local(ctx, wt, Everybody)
 	if len(allUsers) != 1 || allUsers[0] != u1 {
 		t.Fatalf("unexpected list of users in group everybody")
 	}
 
-	allGroups := ListUserGroupsLocal(ctx, wt, u1)
+	allGroups := ListUserGroups_Local(ctx, wt, u1)
 	if len(allGroups) != 1 || allGroups[0] != Everybody {
 		t.Fatalf("unexpected list of groups for user")
 	}
 
-	RemoveUserStageOnly(ctx, wt, u1)
+	RemoveUser_StageOnly(ctx, wt, u1)
 	err := must.Try(func() {
-		GetUserLocal(ctx, wt, u1)
+		GetUser_Local(ctx, wt, u1)
 	})
 	if err == nil {
 		t.Fatalf("expecting error")
 	}
 
-	if IsMemberLocal(ctx, wt, u1, Everybody) {
+	if IsMember_Local(ctx, wt, u1, Everybody) {
 		t.Fatalf("expecting no membership")
 	}
 }

--- a/test/balance/balance_test.go
+++ b/test/balance/balance_test.go
@@ -26,7 +26,7 @@ func TestBalance(t *testing.T) {
 
 	// test balance transfer
 	cloned := gov.Clone(ctx, cty.Gov())
-	balance.TransferStageOnly(ctx, cloned.Tree(), cty.MemberUser(0), bal, cty.MemberUser(1), bal, 10.0)
+	balance.Transfer_StageOnly(ctx, cloned.Tree(), cty.MemberUser(0), bal, cty.MemberUser(1), bal, 10.0)
 	git.Commit(ctx, cloned.Tree(), "test commit")
 	cloned.Push(ctx)
 	actual2 := balance.Get(ctx, cty.Gov(), cty.MemberUser(1), bal)

--- a/test/community.go
+++ b/test/community.go
@@ -54,7 +54,7 @@ func (x *TestCommunity) addEverybody(t *testing.T, ctx context.Context) {
 	govCloned := git.CloneOne(ctx, git.Address(x.gov))
 
 	for i, m := range x.members {
-		member.AddUserByPublicAddressStageOnly(ctx, govCloned.Tree(), x.MemberUser(i), m.Public)
+		member.AddUserByPublicAddress_StageOnly(ctx, govCloned.Tree(), x.MemberUser(i), m.Public)
 	}
 
 	chg := git.NewChangeNoResult("add everybody", "test_add_everybody")


### PR DESCRIPTION
Cron commits can grow large over time. Keeping them in a separate branch ensures users don't fetch them when they use the system. Also the branch can be scrapped or archived occasionally without affecting system operation.