### PR TITLE
output cli results on stdout using a result structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.10.0
 	github.com/google/go-github/v55 v55.0.0
-	github.com/gov4git/lib4git v0.0.28
+	github.com/gov4git/lib4git v0.0.29
 	github.com/gov4git/vendor4git v0.0.3
 	github.com/migueleliasweb/go-github-mock v0.0.19
 	github.com/rogpeppe/go-internal v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.10.0
 	github.com/google/go-github/v55 v55.0.0
-	github.com/gov4git/lib4git v0.0.29
+	github.com/gov4git/lib4git v0.0.30
 	github.com/gov4git/vendor4git v0.0.3
 	github.com/migueleliasweb/go-github-mock v0.0.19
 	github.com/rogpeppe/go-internal v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gov4git/lib4git v0.0.29 h1:QCf1ByuEpq2nkuB9tXSDoTWRvdI8UGnAMx9OH2KrjBo=
-github.com/gov4git/lib4git v0.0.29/go.mod h1:71UoVZBq60omKtVA/+PuP3jlJxhfoUpuS4IyXXLK6tM=
+github.com/gov4git/lib4git v0.0.30 h1:8qBgaFS2ygMns0+80YOvtXt2QSRChOKZC90KYAd0BGE=
+github.com/gov4git/lib4git v0.0.30/go.mod h1:71UoVZBq60omKtVA/+PuP3jlJxhfoUpuS4IyXXLK6tM=
 github.com/gov4git/vendor4git v0.0.3 h1:kT2umpVus0qa+Bqu+8AaX+L1LNyIGnLoaaBR2T6R154=
 github.com/gov4git/vendor4git v0.0.3/go.mod h1:pS09dCJdMmSCfvZefOlPgOBhF5goWxLKAxwHJ9X0d8c=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gov4git/lib4git v0.0.28 h1:G5UWlLs4x/gNLRXRKnDo7ZDFF96ElXthNSFRp3a+nbY=
-github.com/gov4git/lib4git v0.0.28/go.mod h1:71UoVZBq60omKtVA/+PuP3jlJxhfoUpuS4IyXXLK6tM=
+github.com/gov4git/lib4git v0.0.29 h1:QCf1ByuEpq2nkuB9tXSDoTWRvdI8UGnAMx9OH2KrjBo=
+github.com/gov4git/lib4git v0.0.29/go.mod h1:71UoVZBq60omKtVA/+PuP3jlJxhfoUpuS4IyXXLK6tM=
 github.com/gov4git/vendor4git v0.0.3 h1:kT2umpVus0qa+Bqu+8AaX+L1LNyIGnLoaaBR2T6R154=
 github.com/gov4git/vendor4git v0.0.3/go.mod h1:pS09dCJdMmSCfvZefOlPgOBhF5goWxLKAxwHJ9X0d8c=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=

--- a/gov4git/api/result.go
+++ b/gov4git/api/result.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gov4git/lib4git/form"
+	"github.com/gov4git/lib4git/must"
+)
+
+type Result struct {
+	Status   Status `json:"status"`
+	Returned any    `json:"returned,omitempty"`
+	Msg      string `json:"msg,omitempty"`
+}
+
+func Invoke(f func()) Result {
+	r := NewResult(nil, must.Try(f))
+	fmt.Fprint(os.Stdout, form.SprintJSON(r))
+	return r
+}
+
+func Invoke1[R1 any](f func() R1) Result {
+	r1, err := must.Try1[R1](f)
+	r := NewResult(r1, err)
+	fmt.Fprint(os.Stdout, form.SprintJSON(r))
+	return r
+}
+
+func NewResult(r any, err error) Result {
+	var result Result
+	if err == nil {
+		result.Status = StatusSuccess
+	} else {
+		result.Status = StatusError
+		result.Msg = err.Error()
+	}
+	result.Returned = r
+	return result
+}
+
+type Status string
+
+const (
+	StatusSuccess Status = "success"
+	StatusError   Status = "error"
+)

--- a/gov4git/api/result.go
+++ b/gov4git/api/result.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gov4git/lib4git/base"
 	"github.com/gov4git/lib4git/form"
 	"github.com/gov4git/lib4git/must"
 )
@@ -15,14 +16,21 @@ type Result struct {
 }
 
 func Invoke(f func()) Result {
-	r := NewResult(nil, must.Try(f))
+	err := must.TryThru(f)
+	r := NewResult(nil, err.Wrapped())
+	if err != nil && base.IsVerbose() {
+		fmt.Fprint(os.Stderr, string(err.Stack))
+	}
 	fmt.Fprint(os.Stdout, form.SprintJSON(r))
 	return r
 }
 
 func Invoke1[R1 any](f func() R1) Result {
-	r1, err := must.Try1[R1](f)
-	r := NewResult(r1, err)
+	r1, err := must.Try1Thru[R1](f)
+	r := NewResult(r1, err.Wrapped())
+	if err != nil && base.IsVerbose() {
+		fmt.Fprint(os.Stderr, string(err.Stack))
+	}
 	fmt.Fprint(os.Stdout, form.SprintJSON(r))
 	return r
 }

--- a/gov4git/cmd/account.go
+++ b/gov4git/cmd/account.go
@@ -1,11 +1,8 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/gov4git/gov4git/v2/proto/account"
-	"github.com/gov4git/lib4git/form"
 	"github.com/spf13/cobra"
 )
 
@@ -22,16 +19,20 @@ var (
 		Short: "Issue to account",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			account.Issue(
-				ctx,
-				setup.Gov,
-				account.AccountID(accountToID),
-				account.H(
-					account.Asset(accountAsset),
-					accountQuantity,
-				),
-				accountNote,
+			api.Invoke(
+				func() {
+					LoadConfig()
+					account.Issue(
+						ctx,
+						setup.Gov,
+						account.AccountID(accountToID),
+						account.H(
+							account.Asset(accountAsset),
+							accountQuantity,
+						),
+						accountNote,
+					)
+				},
 			)
 		},
 	}
@@ -41,16 +42,20 @@ var (
 		Short: "Burn from account",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			account.Burn(
-				ctx,
-				setup.Gov,
-				account.AccountID(accountFromID),
-				account.H(
-					account.Asset(accountAsset),
-					accountQuantity,
-				),
-				accountNote,
+			api.Invoke(
+				func() {
+					LoadConfig()
+					account.Burn(
+						ctx,
+						setup.Gov,
+						account.AccountID(accountFromID),
+						account.H(
+							account.Asset(accountAsset),
+							accountQuantity,
+						),
+						accountNote,
+					)
+				},
 			)
 		},
 	}
@@ -60,17 +65,21 @@ var (
 		Short: "Transfer from one account to another",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			account.Transfer(
-				ctx,
-				setup.Gov,
-				account.AccountID(accountFromID),
-				account.AccountID(accountToID),
-				account.H(
-					account.Asset(accountAsset),
-					accountQuantity,
-				),
-				accountNote,
+			api.Invoke(
+				func() {
+					LoadConfig()
+					account.Transfer(
+						ctx,
+						setup.Gov,
+						account.AccountID(accountFromID),
+						account.AccountID(accountToID),
+						account.H(
+							account.Asset(accountAsset),
+							accountQuantity,
+						),
+						accountNote,
+					)
+				},
 			)
 		},
 	}
@@ -80,12 +89,15 @@ var (
 		Short: "List accounts",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			v := account.List(
-				ctx,
-				setup.Gov,
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					return account.List(
+						ctx,
+						setup.Gov,
+					)
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(v))
 		},
 	}
 
@@ -94,13 +106,16 @@ var (
 		Short: "Show account",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			v := account.Get(
-				ctx,
-				setup.Gov,
-				account.AccountID(accountID),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					return account.Get(
+						ctx,
+						setup.Gov,
+						account.AccountID(accountID),
+					)
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(v))
 		},
 	}
 
@@ -109,13 +124,17 @@ var (
 		Short: "Show account balance for a given asset",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			v := account.Get(
-				ctx,
-				setup.Gov,
-				account.AccountID(accountID),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					v := account.Get(
+						ctx,
+						setup.Gov,
+						account.AccountID(accountID),
+					)
+					return v.Balance(account.Asset(accountAsset)).Quantity
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(v.Balance(account.Asset(accountAsset)).Quantity))
 		},
 	}
 )

--- a/gov4git/cmd/ballot.go
+++ b/gov4git/cmd/ballot.go
@@ -2,16 +2,14 @@ package cmd
 
 import (
 	"context"
-	"fmt"
-	"os"
 
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/gov4git/gov4git/v2/proto/account"
 	"github.com/gov4git/gov4git/v2/proto/ballot/ballotapi"
 	"github.com/gov4git/gov4git/v2/proto/ballot/ballotio"
 	"github.com/gov4git/gov4git/v2/proto/ballot/ballotproto"
 	"github.com/gov4git/gov4git/v2/proto/member"
 	"github.com/gov4git/gov4git/v2/proto/purpose"
-	"github.com/gov4git/lib4git/form"
 	"github.com/gov4git/lib4git/must"
 	"github.com/spf13/cobra"
 )
@@ -29,21 +27,25 @@ var (
 		Short: "Open a new ballot",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			chg := ballotapi.Open(
-				ctx,
-				ballotio.QVPolicyName,
-				setup.Organizer,
-				ballotproto.ParseBallotID(ballotName),
-				account.NobodyAccountID,
-				purpose.Unspecified,
-				"",
-				ballotTitle,
-				ballotDescription,
-				ballotChoices,
-				member.Group(ballotGroup),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					chg := ballotapi.Open(
+						ctx,
+						ballotio.QVPolicyName,
+						setup.Organizer,
+						ballotproto.ParseBallotID(ballotName),
+						account.NobodyAccountID,
+						purpose.Unspecified,
+						"",
+						ballotTitle,
+						ballotDescription,
+						ballotChoices,
+						member.Group(ballotGroup),
+					)
+					return chg.Result
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 
@@ -52,13 +54,17 @@ var (
 		Short: "Freeze an open ballot",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			chg := ballotapi.Freeze(
-				ctx,
-				setup.Organizer,
-				ballotproto.ParseBallotID(ballotName),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					chg := ballotapi.Freeze(
+						ctx,
+						setup.Organizer,
+						ballotproto.ParseBallotID(ballotName),
+					)
+					return chg.Result
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 
@@ -67,13 +73,17 @@ var (
 		Short: "Unfreeze an open ballot",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			chg := ballotapi.Unfreeze(
-				ctx,
-				setup.Organizer,
-				ballotproto.ParseBallotID(ballotName),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					chg := ballotapi.Unfreeze(
+						ctx,
+						setup.Organizer,
+						ballotproto.ParseBallotID(ballotName),
+					)
+					return chg.Result
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 
@@ -82,14 +92,18 @@ var (
 		Short: "Close an open ballot",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			chg := ballotapi.Close(
-				ctx,
-				setup.Organizer,
-				ballotproto.ParseBallotID(ballotName),
-				account.AccountID(ballotEscrowTo),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					chg := ballotapi.Close(
+						ctx,
+						setup.Organizer,
+						ballotproto.ParseBallotID(ballotName),
+						account.AccountID(ballotEscrowTo),
+					)
+					return chg.Result
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 
@@ -98,13 +112,17 @@ var (
 		Short: "Cancel an open ballot",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			chg := ballotapi.Cancel(
-				ctx,
-				setup.Organizer,
-				ballotproto.ParseBallotID(ballotName),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					chg := ballotapi.Cancel(
+						ctx,
+						setup.Organizer,
+						ballotproto.ParseBallotID(ballotName),
+					)
+					return chg.Result
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 
@@ -113,13 +131,17 @@ var (
 		Short: "Show ballot details",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			r := ballotapi.Show(
-				ctx,
-				setup.Gov,
-				ballotproto.ParseBallotID(ballotName),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					r := ballotapi.Show(
+						ctx,
+						setup.Gov,
+						ballotproto.ParseBallotID(ballotName),
+					)
+					return r
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(r))
 		},
 	}
 
@@ -128,22 +150,24 @@ var (
 		Short: "List ballots",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			ads := ballotapi.ListFilter(
-				ctx,
-				setup.Gov,
-				ballotOnlyOpen,
-				ballotOnlyClosed,
-				ballotOnlyFrozen,
-				member.User(ballotWithParticipant),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					ads := ballotapi.ListFilter(
+						ctx,
+						setup.Gov,
+						ballotOnlyOpen,
+						ballotOnlyClosed,
+						ballotOnlyFrozen,
+						member.User(ballotWithParticipant),
+					)
+					if ballotOnlyNames {
+						return ballotproto.AdsToBallotNames(ads)
+					} else {
+						return ads
+					}
+				},
 			)
-			if ballotOnlyNames {
-				for _, n := range ballotproto.AdsToBallotNames(ads) {
-					fmt.Println(n)
-				}
-			} else {
-				fmt.Fprint(os.Stdout, form.SprintJSON(ads))
-			}
 		},
 	}
 
@@ -152,14 +176,18 @@ var (
 		Short: "Fetch current votes and record latest tally",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			chg := ballotapi.Tally(
-				ctx,
-				setup.Organizer,
-				ballotproto.ParseBallotID(ballotName),
-				ballotFetchPar,
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					chg := ballotapi.Tally(
+						ctx,
+						setup.Organizer,
+						ballotproto.ParseBallotID(ballotName),
+						ballotFetchPar,
+					)
+					return chg.Result
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 
@@ -168,15 +196,19 @@ var (
 		Short: "Cast a vote on an open ballot",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			chg := ballotapi.Vote(
-				ctx,
-				setup.Member,
-				setup.Gov,
-				ballotproto.ParseBallotID(ballotName),
-				parseElections(ctx, ballotElectionChoice, ballotElectionStrength),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					chg := ballotapi.Vote(
+						ctx,
+						setup.Member,
+						setup.Gov,
+						ballotproto.ParseBallotID(ballotName),
+						parseElections(ctx, ballotElectionChoice, ballotElectionStrength),
+					)
+					return chg.Result
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 
@@ -188,14 +220,18 @@ It returns a report listing accepted, rejected and pending votes.
 Rejected votes are associated with a reason, such as "ballot is frozen".
 Pending votes have not yet been processed by the community's governance.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			status := ballotapi.Track(
-				ctx,
-				setup.Member,
-				setup.Gov,
-				ballotproto.ParseBallotID(ballotName),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					status := ballotapi.Track(
+						ctx,
+						setup.Member,
+						setup.Gov,
+						ballotproto.ParseBallotID(ballotName),
+					)
+					return status
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(status))
 		},
 	}
 
@@ -204,13 +240,17 @@ Pending votes have not yet been processed by the community's governance.`,
 		Short: "Erase a ballot",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			chg := ballotapi.Erase(
-				ctx,
-				setup.Organizer,
-				ballotproto.ParseBallotID(ballotName),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					chg := ballotapi.Erase(
+						ctx,
+						setup.Organizer,
+						ballotproto.ParseBallotID(ballotName),
+					)
+					return chg.Result
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 )

--- a/gov4git/cmd/bureau.go
+++ b/gov4git/cmd/bureau.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/gov4git/gov4git/v2/proto/bureau"
 	"github.com/gov4git/gov4git/v2/proto/member"
 	"github.com/spf13/cobra"
@@ -19,11 +20,15 @@ var (
 		Short: "Fetch and process requests from community members",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			bureau.Process(
-				ctx,
-				setup.Organizer,
-				member.Group(bureauGroup),
+			api.Invoke(
+				func() {
+					LoadConfig()
+					bureau.Process(
+						ctx,
+						setup.Organizer,
+						member.Group(bureauGroup),
+					)
+				},
 			)
 		},
 	}
@@ -33,14 +38,18 @@ var (
 		Short: "Make a transfer request to the community governance",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			bureau.Transfer(
-				ctx,
-				setup.Member,
-				setup.Gov,
-				member.User(bureauFromUser),
-				member.User(bureauToUser),
-				bureauAmount,
+			api.Invoke(
+				func() {
+					LoadConfig()
+					bureau.Transfer(
+						ctx,
+						setup.Member,
+						setup.Gov,
+						member.User(bureauFromUser),
+						member.User(bureauToUser),
+						bureauAmount,
+					)
+				},
 			)
 		},
 	}

--- a/gov4git/cmd/cache.go
+++ b/gov4git/cmd/cache.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/gov4git/lib4git/base"
 	lib4git "github.com/gov4git/lib4git/git"
 	"github.com/gov4git/lib4git/must"
@@ -24,10 +25,14 @@ var (
 		Short: "Clear local client cache",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			must.Assertf(ctx, setup.CacheDir != "", "cache dir not specified in config")
-			err := os.RemoveAll(setup.CacheDir)
-			must.NoError(ctx, err)
+			api.Invoke(
+				func() {
+					LoadConfig()
+					must.Assertf(ctx, setup.CacheDir != "", "cache dir not specified in config")
+					err := os.RemoveAll(setup.CacheDir)
+					must.NoError(ctx, err)
+				},
+			)
 		},
 	}
 
@@ -36,16 +41,20 @@ var (
 		Short: "Update local cache by prefetching community and user repos",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			must.Assertf(ctx, setup.CacheDir != "", "cache dir not specified in config")
-			if cacheUpdateIntervalSeconds > 0 {
-				for {
-					updateCacheBestEffort(ctx)
-					time.Sleep(time.Second * time.Duration(cacheUpdateIntervalSeconds))
-				}
-			} else {
-				updateCacheBestEffort(ctx)
-			}
+			api.Invoke(
+				func() {
+					LoadConfig()
+					must.Assertf(ctx, setup.CacheDir != "", "cache dir not specified in config")
+					if cacheUpdateIntervalSeconds > 0 {
+						for {
+							updateCacheBestEffort(ctx)
+							time.Sleep(time.Second * time.Duration(cacheUpdateIntervalSeconds))
+						}
+					} else {
+						updateCacheBestEffort(ctx)
+					}
+				},
+			)
 		},
 	}
 )

--- a/gov4git/cmd/cron.go
+++ b/gov4git/cmd/cron.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
 	"time"
 
 	"github.com/gov4git/gov4git/v2/github"
 	govgh "github.com/gov4git/gov4git/v2/github"
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/gov4git/gov4git/v2/proto/cron"
-	"github.com/gov4git/lib4git/form"
 	"github.com/spf13/cobra"
 )
 
@@ -23,20 +21,24 @@ It will ensure that:
 - Votes from community members are incorporated in governance ballots at a configurable frequency.
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			repo := govgh.ParseRepo(ctx, githubProject)
-			govgh.SetTokenSource(ctx, repo, govgh.MakeStaticTokenSource(ctx, githubToken))
-			ghc := govgh.GetGithubClient(ctx, repo)
-			result := cron.Cron(
-				ctx,
-				repo,
-				ghc,
-				setup.Organizer,
-				time.Duration(cronGithubFreqSeconds)*time.Second,
-				time.Duration(cronCommunityFreqSeconds)*time.Second,
-				syncFetchPar,
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					repo := govgh.ParseRepo(ctx, githubProject)
+					govgh.SetTokenSource(ctx, repo, govgh.MakeStaticTokenSource(ctx, githubToken))
+					ghc := govgh.GetGithubClient(ctx, repo)
+					result := cron.Cron(
+						ctx,
+						repo,
+						ghc,
+						setup.Organizer,
+						time.Duration(cronGithubFreqSeconds)*time.Second,
+						time.Duration(cronCommunityFreqSeconds)*time.Second,
+						syncFetchPar,
+					)
+					return result
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(result))
 		},
 	}
 )

--- a/gov4git/cmd/etc.go
+++ b/gov4git/cmd/etc.go
@@ -2,12 +2,11 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/gov4git/gov4git/v2/proto/etc"
-	"github.com/gov4git/lib4git/form"
 	"github.com/gov4git/lib4git/must"
 	"github.com/spf13/cobra"
 )
@@ -25,9 +24,13 @@ var (
 		Short: "Get system settings",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			settings := etc.GetSettings(ctx, setup.Gov)
-			fmt.Fprint(os.Stdout, form.SprintJSON(settings))
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					settings := etc.GetSettings(ctx, setup.Gov)
+					return settings
+				},
+			)
 		},
 	}
 
@@ -36,16 +39,20 @@ var (
 		Short: "Set system settings",
 		Long:  `System settings must be given as JSON on the standard input.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
+			api.Invoke(
+				func() {
+					LoadConfig()
 
-			jsonData, err := io.ReadAll(os.Stdin)
-			must.NoError(ctx, err)
+					jsonData, err := io.ReadAll(os.Stdin)
+					must.NoError(ctx, err)
 
-			var settings etc.Settings
-			err = json.Unmarshal(jsonData, &settings)
-			must.NoError(ctx, err)
+					var settings etc.Settings
+					err = json.Unmarshal(jsonData, &settings)
+					must.NoError(ctx, err)
 
-			etc.SetSettings(ctx, setup.Gov, settings)
+					etc.SetSettings(ctx, setup.Gov, settings)
+				},
+			)
 		},
 	}
 )

--- a/gov4git/cmd/group.go
+++ b/gov4git/cmd/group.go
@@ -1,11 +1,8 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/gov4git/gov4git/v2/proto/member"
-	"github.com/gov4git/lib4git/form"
 	"github.com/spf13/cobra"
 )
 
@@ -22,13 +19,16 @@ var (
 		Short: "Add group to the community",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			member.AddGroup(
-				ctx,
-				setup.Gov,
-				member.Group(groupName),
+			api.Invoke(
+				func() {
+					LoadConfig()
+					member.AddGroup(
+						ctx,
+						setup.Gov,
+						member.Group(groupName),
+					)
+				},
 			)
-			// fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 
@@ -37,13 +37,16 @@ var (
 		Short: "Remove group from the community",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			member.RemoveGroup(
-				ctx,
-				setup.Gov,
-				member.Group(groupName),
+			api.Invoke(
+				func() {
+					LoadConfig()
+					member.RemoveGroup(
+						ctx,
+						setup.Gov,
+						member.Group(groupName),
+					)
+				},
 			)
-			// fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 
@@ -52,13 +55,16 @@ var (
 		Short: "List users in group",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			l := member.ListGroupUsers(
-				ctx,
-				setup.Gov,
-				member.Group(groupName),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					return member.ListGroupUsers(
+						ctx,
+						setup.Gov,
+						member.Group(groupName),
+					)
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(l))
 		},
 	}
 	groupUsersCmd = &cobra.Command{
@@ -66,13 +72,16 @@ var (
 		Short: "List users in group",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			l := member.ListGroupUsers(
-				ctx,
-				setup.Gov,
-				member.Group(groupName),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					return member.ListGroupUsers(
+						ctx,
+						setup.Gov,
+						member.Group(groupName),
+					)
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(l))
 		},
 	}
 )

--- a/gov4git/cmd/init.go
+++ b/gov4git/cmd/init.go
@@ -1,12 +1,9 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/gov4git/gov4git/v2/proto/boot"
 	"github.com/gov4git/gov4git/v2/proto/id"
-	"github.com/gov4git/lib4git/form"
 	"github.com/spf13/cobra"
 )
 
@@ -16,9 +13,13 @@ var (
 		Short: "Initialize public and private repositories of your identity",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			chg := id.Init(ctx, setup.Member)
-			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					chg := id.Init(ctx, setup.Member)
+					return chg.Result
+				},
+			)
 		},
 	}
 
@@ -27,9 +28,13 @@ var (
 		Short: "Initialize public and private repositories of your governance",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			chg := boot.Boot(ctx, setup.Organizer)
-			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					chg := boot.Boot(ctx, setup.Organizer)
+					return chg.Result
+				},
+			)
 		},
 	}
 )

--- a/gov4git/cmd/member.go
+++ b/gov4git/cmd/member.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/gov4git/gov4git/v2/proto/member"
 	"github.com/spf13/cobra"
 )
@@ -18,12 +19,16 @@ var (
 		Short: "Add member",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			member.AddMember(
-				ctx,
-				setup.Gov,
-				member.User(memberUser),
-				member.Group(memberGroup),
+			api.Invoke(
+				func() {
+					LoadConfig()
+					member.AddMember(
+						ctx,
+						setup.Gov,
+						member.User(memberUser),
+						member.Group(memberGroup),
+					)
+				},
 			)
 		},
 	}
@@ -33,12 +38,16 @@ var (
 		Short: "Remove member from the community",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			member.RemoveMember(
-				ctx,
-				setup.Gov,
-				member.User(memberUser),
-				member.Group(memberGroup),
+			api.Invoke(
+				func() {
+					LoadConfig()
+					member.RemoveMember(
+						ctx,
+						setup.Gov,
+						member.User(memberUser),
+						member.Group(memberGroup),
+					)
+				},
 			)
 		},
 	}

--- a/gov4git/cmd/motions.go
+++ b/gov4git/cmd/motions.go
@@ -1,15 +1,13 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
 	"strings"
 
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/gov4git/gov4git/v2/proto/member"
 	"github.com/gov4git/gov4git/v2/proto/motion"
 	"github.com/gov4git/gov4git/v2/proto/motion/motionapi"
 	"github.com/gov4git/gov4git/v2/proto/motion/motionproto"
-	"github.com/gov4git/lib4git/form"
 	"github.com/spf13/cobra"
 )
 
@@ -26,20 +24,23 @@ var (
 		Short: "Open a new motion",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			motionapi.OpenMotion(
-				ctx,
-				setup.Organizer,
-				motionproto.MotionID(motionName),
-				motionproto.ParseMotionType(ctx, motionType),
-				motion.PolicyName(motionPolicy),
-				member.User(motionAuthor),
-				motionTitle,
-				motionDesc,
-				motionTrackerURL,
-				nil,
+			api.Invoke(
+				func() {
+					LoadConfig()
+					motionapi.OpenMotion(
+						ctx,
+						setup.Organizer,
+						motionproto.MotionID(motionName),
+						motionproto.ParseMotionType(ctx, motionType),
+						motion.PolicyName(motionPolicy),
+						member.User(motionAuthor),
+						motionTitle,
+						motionDesc,
+						motionTrackerURL,
+						nil,
+					)
+				},
 			)
-			// fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 
@@ -48,20 +49,23 @@ var (
 		Short: "Close a motion",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			var d motionproto.Decision
-			if motionAccept {
-				d = motionproto.Accept
-			} else {
-				d = motionproto.Reject
-			}
-			motionapi.CloseMotion(
-				ctx,
-				setup.Organizer,
-				motionproto.MotionID(motionName),
-				d,
+			api.Invoke(
+				func() {
+					LoadConfig()
+					var d motionproto.Decision
+					if motionAccept {
+						d = motionproto.Accept
+					} else {
+						d = motionproto.Reject
+					}
+					motionapi.CloseMotion(
+						ctx,
+						setup.Organizer,
+						motionproto.MotionID(motionName),
+						d,
+					)
+				},
 			)
-			// fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 
@@ -70,14 +74,16 @@ var (
 		Short: "List motions",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			if motionTrack {
-				mvs := motionapi.TrackMotionBatch(ctx, setup.Gov, setup.Member)
-				fmt.Fprint(os.Stdout, form.SprintJSON(mvs))
-			} else {
-				l := motionapi.ListMotionViews(ctx, setup.Gov)
-				fmt.Fprint(os.Stdout, form.SprintJSON(l))
-			}
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					if motionTrack {
+						return motionapi.TrackMotionBatch(ctx, setup.Gov, setup.Member)
+					} else {
+						return motionapi.ListMotionViews(ctx, setup.Gov)
+					}
+				},
+			)
 		},
 	}
 
@@ -86,14 +92,16 @@ var (
 		Short: "Show motion state and associated objects",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			if motionTrack {
-				s := motionapi.TrackMotion(ctx, setup.Gov, setup.Member, motionproto.MotionID(motionName))
-				fmt.Fprint(os.Stdout, form.SprintJSON(s))
-			} else {
-				mv := motionapi.ShowMotion(ctx, setup.Gov, motionproto.MotionID(motionName))
-				fmt.Fprint(os.Stdout, form.SprintJSON(mv))
-			}
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					if motionTrack {
+						return motionapi.TrackMotion(ctx, setup.Gov, setup.Member, motionproto.MotionID(motionName))
+					} else {
+						return motionapi.ShowMotion(ctx, setup.Gov, motionproto.MotionID(motionName))
+					}
+				},
+			)
 		},
 	}
 )

--- a/gov4git/cmd/panorama.go
+++ b/gov4git/cmd/panorama.go
@@ -1,11 +1,8 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/gov4git/gov4git/v2/proto/panorama"
-	"github.com/gov4git/lib4git/form"
 	"github.com/spf13/cobra"
 )
 
@@ -15,9 +12,12 @@ var (
 		Short: "Panoramic view of user and motions, capturing pending votes",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			pano := panorama.Panorama(ctx, setup.Gov, setup.Member)
-			fmt.Fprint(os.Stdout, form.SprintJSON(pano))
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					return panorama.Panorama(ctx, setup.Gov, setup.Member)
+				},
+			)
 		},
 	}
 )

--- a/gov4git/cmd/sync.go
+++ b/gov4git/cmd/sync.go
@@ -1,11 +1,8 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/gov4git/gov4git/v2/proto/sync"
-	"github.com/gov4git/lib4git/form"
 	"github.com/spf13/cobra"
 )
 
@@ -18,9 +15,13 @@ Sync is the heartbeat that advances the state of the governance forward.
 Sync fetches all outstanding votes from community users and incorporates them in ballot tallies.
 Sync also fetches and processes all outstanding service requests from community users.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			chg := sync.Sync(ctx, setup.Organizer, syncFetchPar)
-			fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					chg := sync.Sync(ctx, setup.Organizer, syncFetchPar)
+					return chg.Result
+				},
+			)
 		},
 	}
 )

--- a/gov4git/cmd/user.go
+++ b/gov4git/cmd/user.go
@@ -1,12 +1,9 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/gov4git/gov4git/v2/proto/id"
 	"github.com/gov4git/gov4git/v2/proto/member"
-	"github.com/gov4git/lib4git/form"
 	"github.com/gov4git/lib4git/git"
 	"github.com/spf13/cobra"
 )
@@ -24,14 +21,17 @@ var (
 		Short: "Add user to the community",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			member.AddUserByPublicAddress(
-				ctx,
-				setup.Gov,
-				member.User(userName),
-				id.PublicAddress{Repo: git.URL(userRepo), Branch: git.Branch(userBranch)},
+			api.Invoke(
+				func() {
+					LoadConfig()
+					member.AddUserByPublicAddress(
+						ctx,
+						setup.Gov,
+						member.User(userName),
+						id.PublicAddress{Repo: git.URL(userRepo), Branch: git.Branch(userBranch)},
+					)
+				},
 			)
-			// fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 
@@ -40,13 +40,16 @@ var (
 		Short: "Remove user from the community",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			member.RemoveUser(
-				ctx,
-				setup.Gov,
-				member.User(userName),
+			api.Invoke(
+				func() {
+					LoadConfig()
+					member.RemoveUser(
+						ctx,
+						setup.Gov,
+						member.User(userName),
+					)
+				},
 			)
-			// fmt.Fprint(os.Stdout, form.SprintJSON(chg.Result))
 		},
 	}
 
@@ -55,14 +58,17 @@ var (
 		Short: "Get user property",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			v := member.GetUserProp[interface{}](
-				ctx,
-				setup.Gov,
-				member.User(userName),
-				userKey,
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					return member.GetUserProp[interface{}](
+						ctx,
+						setup.Gov,
+						member.User(userName),
+						userKey,
+					)
+				},
 			)
-			fmt.Fprint(os.Stdout, v)
 		},
 	}
 
@@ -71,13 +77,16 @@ var (
 		Short: "List user's group memberships",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			LoadConfig()
-			l := member.ListUserGroups(
-				ctx,
-				setup.Gov,
-				member.User(userName),
+			api.Invoke1(
+				func() any {
+					LoadConfig()
+					return member.ListUserGroups(
+						ctx,
+						setup.Gov,
+						member.User(userName),
+					)
+				},
 			)
-			fmt.Fprint(os.Stdout, form.SprintJSON(l))
 		},
 	}
 )

--- a/gov4git/cmd/version.go
+++ b/gov4git/cmd/version.go
@@ -1,11 +1,8 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/gov4git/gov4git/v2"
-	"github.com/gov4git/lib4git/form"
+	"github.com/gov4git/gov4git/v2/gov4git/api"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +12,11 @@ var (
 		Short: "Version and build information",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprint(os.Stdout, form.SprintJSON(gov4git.GetVersionInfo()))
+			api.Invoke1(
+				func() any {
+					return gov4git.GetVersionInfo()
+				},
+			)
 		},
 	}
 )


### PR DESCRIPTION
The cli tool will always return a structured result on stdout, and a stack trace —if applicable, and `-v` flag used — on stderr. The structured result is defined in Go as:

```go
type Result struct {
	Status   Status `json:"status"`
	Returned any    `json:"returned,omitempty"`
	Msg      string `json:"msg,omitempty"`   // summary of error
	Error    error  `json:"error,omitempty"` // structure of error
}
```

The `Status` is a string, which currently can be one of `success` or `error`. In the event of success, `Returned` holds the result. In the event of error, `Msg` holds a summary of the error, whereas `Error` holds a JSON structure describing the error. The latter may come handy if we need to use structured information in error reports.

partially addresses https://github.com/gov4git/gov4git/issues/166