### PR TITLE
forward compat: handle unknown policies gracefully

### DIFF
--- a/proto/ballot/ballotapi/cancel.go
+++ b/proto/ballot/ballotapi/cancel.go
@@ -35,7 +35,7 @@ func Cancel_StageOnly(
 	t := cloned.Public.Tree()
 
 	// verify ad and policy are present
-	ad, policy := ballotio.LoadPolicy(ctx, t, id)
+	ad, policy := ballotio.LoadAdPolicy_Local(ctx, t, id)
 	must.Assertf(ctx, !ad.Closed, "ballot already closed")
 
 	tally := loadTally_Local(ctx, t, id)

--- a/proto/ballot/ballotapi/change.go
+++ b/proto/ballot/ballotapi/change.go
@@ -38,7 +38,7 @@ func Change_StageOnly(
 
 ) git.Change[form.Map, ballotproto.Ad] {
 
-	ad, _ := ballotio.LoadPolicy(ctx, cloned.Public.Tree(), id)
+	ad := ballotio.LoadAd_Local(ctx, cloned.Public.Tree(), id)
 	ad.Title = title
 	ad.Description = description
 	git.ToFileStage(ctx, cloned.Public.Tree(), id.AdNS(), ad)

--- a/proto/ballot/ballotapi/close.go
+++ b/proto/ballot/ballotapi/close.go
@@ -41,13 +41,13 @@ func Close_StageOnly(
 	t := cloned.Public.Tree()
 
 	// verify ad and policy are present
-	ad, strat := ballotio.LoadPolicy(ctx, t, id)
+	ad, policy := ballotio.LoadAdPolicy_Local(ctx, t, id)
 	must.Assertf(ctx, !ad.Closed, "ballot already closed")
 
 	tally := loadTally_Local(ctx, t, id)
 
 	var chg git.Change[map[string]form.Form, ballotproto.Outcome]
-	chg = strat.Close(ctx, cloned, &ad, &tally)
+	chg = policy.Close(ctx, cloned, &ad, &tally)
 
 	// write outcome
 	git.ToFileStage(ctx, t, id.OutcomeNS(), chg.Result)

--- a/proto/ballot/ballotapi/erase.go
+++ b/proto/ballot/ballotapi/erase.go
@@ -36,8 +36,8 @@ func Erase_StageOnly(
 
 	t := cloned.Public.Tree()
 
-	// verify ad and policy are present
-	ballotio.LoadPolicy(ctx, t, ballotID)
+	// verify ad is present
+	ballotio.LoadAd_Local(ctx, t, ballotID)
 
 	// erase
 	ballotproto.BallotKV.Remove(ctx, ballotproto.BallotNS, cloned.PublicClone().Tree(), ballotID)

--- a/proto/ballot/ballotapi/freeze.go
+++ b/proto/ballot/ballotapi/freeze.go
@@ -36,7 +36,7 @@ func Freeze_StageOnly(
 
 	t := cloned.Public.Tree()
 
-	ad, _ := ballotio.LoadPolicy(ctx, t, id)
+	ad := ballotio.LoadAd_Local(ctx, t, id)
 
 	must.Assertf(ctx, !ad.Closed, "ballot is closed")
 	must.Assertf(ctx, !ad.Frozen, "ballot already frozen")
@@ -62,6 +62,6 @@ func IsFrozen_Local(
 
 ) bool {
 
-	ad, _ := ballotio.LoadPolicy(ctx, cloned.Tree(), id)
+	ad := ballotio.LoadAd_Local(ctx, cloned.Tree(), id)
 	return ad.Frozen
 }

--- a/proto/ballot/ballotapi/list.go
+++ b/proto/ballot/ballotapi/list.go
@@ -3,6 +3,7 @@ package ballotapi
 import (
 	"context"
 
+	"github.com/gov4git/gov4git/v2/proto/ballot/ballotio"
 	"github.com/gov4git/gov4git/v2/proto/ballot/ballotproto"
 	"github.com/gov4git/gov4git/v2/proto/gov"
 	"github.com/gov4git/gov4git/v2/proto/member"
@@ -29,7 +30,9 @@ func List_Local(
 	ads := ballotproto.Advertisements{}
 	for _, id := range ids {
 		ad := git.FromFile[ballotproto.Ad](ctx, cloned.Tree(), id.AdNS())
-		ads = append(ads, ad)
+		if ballotio.TryLookupPolicy(ctx, ad.Policy) != nil {
+			ads = append(ads, ad)
+		}
 	}
 
 	ads.Sort()

--- a/proto/ballot/ballotapi/margin.go
+++ b/proto/ballot/ballotapi/margin.go
@@ -27,7 +27,7 @@ func GetMargin_Local(
 ) *ballotproto.Margin {
 
 	t := cloned.Tree()
-	ad, policy := ballotio.LoadPolicy(ctx, t, id)
+	ad, policy := ballotio.LoadAdPolicy_Local(ctx, t, id)
 	tally := loadTally_Local(ctx, t, id)
 	return policy.Margin(ctx, cloned, &ad, &tally)
 }

--- a/proto/ballot/ballotapi/policy.go
+++ b/proto/ballot/ballotapi/policy.go
@@ -57,7 +57,7 @@ func SavePolicyState_StageOnly[PS form.Form](
 ) {
 
 	t := cloned.Tree()
-	ad, _ := ballotio.LoadPolicy(ctx, t, id)
+	ad := ballotio.LoadAd_Local(ctx, t, id)
 	must.Assertf(ctx, !ad.Closed, "ballot already closed")
 	git.ToFileStage[PS](ctx, t, id.PolicyNS(), policyState)
 }

--- a/proto/ballot/ballotapi/reopen.go
+++ b/proto/ballot/ballotapi/reopen.go
@@ -36,12 +36,12 @@ func Reopen_StageOnly(
 	t := cloned.Public.Tree()
 
 	// verify ad and policy are present
-	ad, strat := ballotio.LoadPolicy(ctx, t, id)
+	ad, policy := ballotio.LoadAdPolicy_Local(ctx, t, id)
 	must.Assertf(ctx, ad.Closed, "ballot is not closed")
 	must.Assertf(ctx, !ad.Cancelled, "ballot was cancelled")
 
 	tally := loadTally_Local(ctx, t, id)
-	chg := strat.Reopen(ctx, cloned, &ad, &tally)
+	chg := policy.Reopen(ctx, cloned, &ad, &tally)
 
 	// remove prior outcome
 	_, err := git.TreeRemove(ctx, t, id.OutcomeNS())

--- a/proto/ballot/ballotapi/show.go
+++ b/proto/ballot/ballotapi/show.go
@@ -27,7 +27,7 @@ func Show_Local(
 
 ) ballotproto.AdTally {
 
-	ad, _ := ballotio.LoadPolicy(ctx, t, id)
+	ad := ballotio.LoadAd_Local(ctx, t, id)
 	var tally ballotproto.Tally
 	must.Try(func() { tally = loadTally_Local(ctx, t, id) })
 	return ballotproto.AdTally{Ad: ad, Tally: tally}

--- a/proto/ballot/ballotapi/tally.go
+++ b/proto/ballot/ballotapi/tally.go
@@ -45,7 +45,7 @@ func Tally_StageOnly(
 ) (git.Change[form.Map, ballotproto.Tally], bool) {
 
 	t := cloned.Public.Tree()
-	ad, _ := ballotio.LoadPolicy(ctx, t, id)
+	ad := ballotio.LoadAd_Local(ctx, t, id)
 
 	pv := loadParticipatingVoters(ctx, cloned.PublicClone(), ad)
 	votersCloned := clonePar(ctx, pv.VoterAccounts, maxPar)
@@ -105,7 +105,7 @@ func TallyFetchedVotes_StageOnly(
 ) (git.Change[form.Map, ballotproto.Tally], bool) {
 
 	t := cloned.Tree()
-	ad, strat := ballotio.LoadPolicy(ctx, t, id)
+	ad, policy := ballotio.LoadAdPolicy_Local(ctx, t, id)
 	must.Assertf(ctx, !ad.Closed, "ballot is closed")
 
 	currentTally := loadTally_Local(ctx, t, id)
@@ -137,7 +137,7 @@ func TallyFetchedVotes_StageOnly(
 		), true
 	}
 
-	updatedTally := strat.Tally(ctx, cloned, &ad, &currentTally, fetchedVotesToElections(fetchedVotes)).Result
+	updatedTally := policy.Tally(ctx, cloned, &ad, &currentTally, fetchedVotesToElections(fetchedVotes)).Result
 
 	// write updated tally
 	git.ToFileStage(ctx, t, id.TallyNS(), updatedTally)

--- a/proto/ballot/ballotapi/unfreeze.go
+++ b/proto/ballot/ballotapi/unfreeze.go
@@ -36,8 +36,8 @@ func Unfreeze_StageOnly(
 
 	t := cloned.Public.Tree()
 
-	// verify ad and policy are present
-	ad, _ := ballotio.LoadPolicy(ctx, t, id)
+	// verify ad is present
+	ad := ballotio.LoadAd_Local(ctx, t, id)
 
 	must.Assertf(ctx, !ad.Closed, "ballot is closed")
 	must.Assertf(ctx, ad.Frozen, "ballot is not frozen")

--- a/proto/ballot/ballotapi/vote.go
+++ b/proto/ballot/ballotapi/vote.go
@@ -42,12 +42,12 @@ func Vote_StageOnly(
 
 ) git.Change[form.Map, mail.RequestEnvelope[ballotproto.VoteEnvelope]] {
 
-	ad, strat := ballotio.LoadPolicy(ctx, cloned.Tree(), ballotID)
+	ad, policy := ballotio.LoadAdPolicy_Local(ctx, cloned.Tree(), ballotID)
 
 	must.Assertf(ctx, !ad.Closed, "ballot is closed")
 	must.Assertf(ctx, !ad.Frozen, "ballot is frozen")
 
-	verifyElections(ctx, strat, voterAddr, cloned.Address(), voterOwner, cloned, ad, elections)
+	verifyElections(ctx, policy, voterAddr, cloned.Address(), voterOwner, cloned, ad, elections)
 	envelope := ballotproto.VoteEnvelope{
 		AdCommit:  git.Head(ctx, cloned.Repo()),
 		Ad:        ad,

--- a/proto/ballot/ballotio/policies.go
+++ b/proto/ballot/ballotio/policies.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gov4git/gov4git/v2/proto/ballot/ballotproto"
 	"github.com/gov4git/gov4git/v2/proto/mod"
 	"github.com/gov4git/lib4git/git"
+	"github.com/gov4git/lib4git/must"
 )
 
 var policyRegistry = mod.NewModuleRegistry[ballotproto.PolicyName, ballotproto.Policy]()
@@ -30,15 +31,33 @@ func Install(ctx context.Context, name ballotproto.PolicyName, policy ballotprot
 	policyRegistry.Set(ctx, name, policy)
 }
 
-func LoadPolicy(
+func LoadAd_Local(
+	ctx context.Context,
+	t *git.Tree,
+	id ballotproto.BallotID,
+
+) ballotproto.Ad {
+
+	return git.FromFile[ballotproto.Ad](ctx, t, id.AdNS())
+}
+
+func LoadAdPolicy_Local(
 	ctx context.Context,
 	t *git.Tree,
 	id ballotproto.BallotID,
 
 ) (ballotproto.Ad, ballotproto.Policy) {
 
-	ad := git.FromFile[ballotproto.Ad](ctx, t, id.AdNS())
-	return ad, policyRegistry.Get(ctx, ad.Policy)
+	ad := LoadAd_Local(ctx, t, id)
+
+	p, err := must.Try1[ballotproto.Policy](
+		func() ballotproto.Policy {
+			return policyRegistry.Get(ctx, ad.Policy)
+		},
+	)
+	must.Assertf(ctx, err == nil, "ballot policy not supported") // ERR
+
+	return ad, p
 }
 
 func LookupPolicy(
@@ -48,4 +67,18 @@ func LookupPolicy(
 ) ballotproto.Policy {
 
 	return policyRegistry.Get(ctx, id)
+}
+
+func TryLookupPolicy(
+	ctx context.Context,
+	id ballotproto.PolicyName,
+
+) ballotproto.Policy {
+
+	p, _ := must.Try1[ballotproto.Policy](
+		func() ballotproto.Policy {
+			return policyRegistry.Get(ctx, id)
+		},
+	)
+	return p
 }

--- a/proto/motion/motionapi/cancel.go
+++ b/proto/motion/motionapi/cancel.go
@@ -40,7 +40,7 @@ func CancelMotion_StageOnly(
 	must.Assertf(ctx, !motion.Cancelled, "motion %v already cancelled", motion.ID)
 
 	// apply policy
-	pcy := motionproto.Get(ctx, motion.Policy)
+	pcy := motionproto.GetPolicy(ctx, motion.Policy)
 	report, notices := pcy.Cancel(
 		ctx,
 		cloned,

--- a/proto/motion/motionapi/close.go
+++ b/proto/motion/motionapi/close.go
@@ -41,7 +41,7 @@ func CloseMotion_StageOnly(
 	must.Assert(ctx, !motion.Closed, motionproto.ErrMotionAlreadyClosed)
 
 	// apply policy
-	pcy := motionproto.Get(ctx, motion.Policy)
+	pcy := motionproto.GetPolicy(ctx, motion.Policy)
 	report, notices := pcy.Close(
 		ctx,
 		cloned,

--- a/proto/motion/motionapi/freeze.go
+++ b/proto/motion/motionapi/freeze.go
@@ -40,7 +40,7 @@ func FreezeMotion_StageOnly(
 	must.Assert(ctx, !motion.Frozen, motionproto.ErrMotionAlreadyFrozen)
 
 	// apply policy
-	pcy := motionproto.Get(ctx, motion.Policy)
+	pcy := motionproto.GetPolicy(ctx, motion.Policy)
 	report, notices := pcy.Freeze(
 		ctx,
 		cloned,
@@ -92,7 +92,7 @@ func UnfreezeMotion_StageOnly(
 	must.Assert(ctx, motion.Frozen, motionproto.ErrMotionNotFrozen)
 
 	// apply policy
-	pcy := motionproto.Get(ctx, motion.Policy)
+	pcy := motionproto.GetPolicy(ctx, motion.Policy)
 	report, notices := pcy.Unfreeze(
 		ctx,
 		cloned,

--- a/proto/motion/motionapi/link.go
+++ b/proto/motion/motionapi/link.go
@@ -52,8 +52,8 @@ func LinkMotions_StageOnly(
 	motionproto.MotionKV.Set(ctx, motionproto.MotionNS, t, toID, to)
 
 	// apply policies
-	fromPolicy := motionproto.Get(ctx, from.Policy)
-	toPolicy := motionproto.Get(ctx, to.Policy)
+	fromPolicy := motionproto.GetPolicy(ctx, from.Policy)
+	toPolicy := motionproto.GetPolicy(ctx, to.Policy)
 
 	// AddRefs are called in the opposite order of RemoveRefs
 	reportFrom, noticesFrom := fromPolicy.AddRefFrom(

--- a/proto/motion/motionapi/list.go
+++ b/proto/motion/motionapi/list.go
@@ -24,8 +24,14 @@ func ListMotions_Local(
 ) motionproto.Motions {
 
 	_, motions := motionproto.MotionKV.ListKeyValues(ctx, motionproto.MotionNS, t)
-	motionproto.MotionsByID(motions).Sort()
-	return motions
+	knownPolicyMotions := motionproto.Motions{}
+	for _, m := range motions {
+		if motionproto.TryGetPolicy(ctx, m.Policy) != nil {
+			knownPolicyMotions = append(knownPolicyMotions, m)
+		}
+	}
+	motionproto.MotionsByID(knownPolicyMotions).Sort()
+	return knownPolicyMotions
 }
 
 func ListMotionViews(

--- a/proto/motion/motionapi/list.go
+++ b/proto/motion/motionapi/list.go
@@ -45,9 +45,12 @@ func ListMotionViews_Local(
 
 	t := cloned.Tree()
 	ids := motionproto.MotionKV.ListKeys(ctx, motionproto.MotionNS, t)
-	mvs := make(motionproto.MotionViews, len(ids))
-	for i, id := range ids {
-		mvs[i] = ShowMotion_Local(ctx, cloned, id)
+	mvs := make(motionproto.MotionViews, 0, len(ids))
+	for _, id := range ids {
+		mv := ShowMotion_Local(ctx, cloned, id)
+		if !mv.IsMissingPolicy() {
+			mvs = append(mvs, mv)
+		}
 	}
 	mvs.Sort()
 	return mvs

--- a/proto/motion/motionapi/open.go
+++ b/proto/motion/motionapi/open.go
@@ -73,7 +73,7 @@ func OpenMotion_StageOnly(
 	motionproto.MotionKV.Set(ctx, motionproto.MotionNS, t, id, motion)
 
 	// apply policy
-	pcy := motionproto.Get(ctx, policyName)
+	pcy := motionproto.GetPolicy(ctx, policyName)
 	report, notices := pcy.Open(
 		ctx,
 		cloned,

--- a/proto/motion/motionapi/show.go
+++ b/proto/motion/motionapi/show.go
@@ -31,7 +31,7 @@ func ShowMotion_Local(
 
 	mv, err := must.Try1[motionproto.MotionView](
 		func() motionproto.MotionView {
-			p := motionproto.Get(ctx, m.Policy)
+			p := motionproto.GetPolicy(ctx, m.Policy)
 			pv, pb := p.Show(ctx, cloned, m, args...)
 
 			return motionproto.MotionView{

--- a/proto/motion/motionapi/unlink.go
+++ b/proto/motion/motionapi/unlink.go
@@ -52,8 +52,8 @@ func UnlinkMotions_StageOnly(
 	motionproto.MotionKV.Set(ctx, motionproto.MotionNS, t, toID, to)
 
 	// apply policies
-	fromPolicy := motionproto.Get(ctx, from.Policy)
-	toPolicy := motionproto.Get(ctx, to.Policy)
+	fromPolicy := motionproto.GetPolicy(ctx, from.Policy)
+	toPolicy := motionproto.GetPolicy(ctx, to.Policy)
 	// RemoveRefs are called in the opposite order of AddRefs
 	reportTo, noticesTo := toPolicy.RemoveRefTo(
 		ctx,

--- a/proto/motion/motionproto/policy.go
+++ b/proto/motion/motionproto/policy.go
@@ -160,7 +160,16 @@ func Install(ctx context.Context, name motion.PolicyName, policy Policy) {
 	gov.InstallPostClone(ctx, "motion-policy-"+string(name), policy)
 }
 
-func Get(ctx context.Context, key motion.PolicyName) Policy {
+func TryGetPolicy(ctx context.Context, key motion.PolicyName) Policy {
+	p, _ := must.Try1[Policy](
+		func() Policy {
+			return policyRegistry.Get(ctx, key)
+		},
+	)
+	return p
+}
+
+func GetPolicy(ctx context.Context, key motion.PolicyName) Policy {
 	p, err := must.Try1[Policy](
 		func() Policy {
 			return policyRegistry.Get(ctx, key)
@@ -187,7 +196,7 @@ func GetMotionPolicy(ctx context.Context, m Motion) Policy {
 }
 
 func GetMotionPolicyByName(ctx context.Context, pn motion.PolicyName) Policy {
-	return Get(ctx, pn)
+	return GetPolicy(ctx, pn)
 }
 
 // MotionPolicyNS returns the private policy namespace for a given motion instance.

--- a/proto/motion/motionproto/policy.go
+++ b/proto/motion/motionproto/policy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gov4git/gov4git/v2/proto/motion"
 	"github.com/gov4git/gov4git/v2/proto/notice"
 	"github.com/gov4git/lib4git/form"
+	"github.com/gov4git/lib4git/must"
 	"github.com/gov4git/lib4git/ns"
 )
 
@@ -160,7 +161,13 @@ func Install(ctx context.Context, name motion.PolicyName, policy Policy) {
 }
 
 func Get(ctx context.Context, key motion.PolicyName) Policy {
-	return policyRegistry.Get(ctx, key)
+	p, err := must.Try1[Policy](
+		func() Policy {
+			return policyRegistry.Get(ctx, key)
+		},
+	)
+	must.Assertf(ctx, err == nil, "unsupported motion policy") // ERR
+	return p
 }
 
 func InstalledMotionPolicies() []string {

--- a/proto/motion/motionproto/policy.go
+++ b/proto/motion/motionproto/policy.go
@@ -166,7 +166,7 @@ func Get(ctx context.Context, key motion.PolicyName) Policy {
 			return policyRegistry.Get(ctx, key)
 		},
 	)
-	must.Assertf(ctx, err == nil, "unsupported motion policy") // ERR
+	must.Assertf(ctx, err == nil, "motion policy not supported") // ERR
 	return p
 }
 

--- a/proto/motion/motionproto/view.go
+++ b/proto/motion/motionproto/view.go
@@ -14,6 +14,10 @@ type MotionView struct {
 	Voter   *ballotproto.VoterStatus `json:"voter_status,omitempty"`
 }
 
+func (mv MotionView) IsMissingPolicy() bool {
+	return mv.Policy == nil
+}
+
 type MotionViews []MotionView
 
 func (x MotionViews) Len() int {

--- a/proto/panorama/panorama.go
+++ b/proto/panorama/panorama.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gov4git/gov4git/v2/proto/account"
 	"github.com/gov4git/gov4git/v2/proto/ballot/ballotapi"
+	"github.com/gov4git/gov4git/v2/proto/ballot/ballotio"
 	"github.com/gov4git/gov4git/v2/proto/gov"
 	"github.com/gov4git/gov4git/v2/proto/id"
 	"github.com/gov4git/gov4git/v2/proto/member"
@@ -59,6 +60,9 @@ func Panorama_Local(
 		// 	voterProfile,
 		// 	voterOwner.PublicClone(),
 		// )
+		if ballotio.TryLookupPolicy(ctx, ad.Policy) == nil { // only consider ballots with known policies
+			continue
+		}
 		if ad.Closed {
 			continue
 		}
@@ -83,8 +87,7 @@ func Panorama_Local(
 	}
 
 	// rescore and update motions
-	motionapi.ScoreMotions_StageOnly(ctx, gov.LiftCloned(ctx, cloned))
-	motionapi.UpdateMotions_StageOnly(ctx, gov.LiftCloned(ctx, cloned))
+	motionapi.Pipeline(ctx, gov.LiftCloned(ctx, cloned))
 
 	projMVS := motionapi.TrackMotionBatch_Local(ctx, cloned, voterAddr, voterOwner)
 	// TODO: fully simulate tallying by processing voter's mail (see above)


### PR DESCRIPTION
- ballots or motions with unsupported policies are not included in `list` output
- `motion show` does not include policy information, when the policy is unknown
- exclude motions with unsupported policies from `panorama`

resolves https://github.com/gov4git/gov4git/issues/172